### PR TITLE
feat: switch to fully tree-shakeable ESM build with preserveModules

### DIFF
--- a/.changeset/tree-shaking-esm-build.md
+++ b/.changeset/tree-shaking-esm-build.md
@@ -1,0 +1,16 @@
+---
+'entangle-ui': minor
+---
+
+Switch to fully tree-shakeable ESM build with preserveModules
+
+- Replace monolithic bundle with per-module ESM output (`dist/esm/`)
+- Drop CJS output — ESM-only package
+- Add `sideEffects: false` and `exports` field to package.json
+- Fix externals: add @emotion/react, @emotion/styled, @floating-ui/react, react/jsx-runtime
+- Fix wrong external name: @base-ui/react → @base-ui-components/react
+- Remove @emotion/react and @emotion/styled from dependencies (keep in peerDependencies only)
+- Add `/*#__PURE__*/` annotations for tree-shaking (Object.assign, createContext, React.memo, forwardRef)
+- Add `entangle-ui/palettes` deep import entry point
+- Add size-limit bundle size guards
+- Create tsconfig.build.json (excludes tests/stories from build)

--- a/.npmignore
+++ b/.npmignore
@@ -22,11 +22,16 @@ rollup.config.js
 vite.config.ts
 vitest.config.ts
 tsconfig.json
+tsconfig.build.json
 eslint.config.js
 prettier.config.js
+.size-limit.json
 
 # Misc
 .vscode/
 .idea/
+.claude/
+.changeset/
+tmp_tasks/
 *.log
 .DS_Store

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "Single component (Button)",
+    "path": "dist/esm/components/primitives/Button/index.js",
+    "limit": "15 kB"
+  },
+  {
+    "name": "Theme only",
+    "path": "dist/esm/theme/index.js",
+    "limit": "5 kB"
+  },
+  {
+    "name": "Full library",
+    "path": "dist/esm/index.js",
+    "limit": "250 kB"
+  }
+]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Entangle UI is a React component library for professional editor interfaces (3D 
 | Task            | Command                                                                     |
 | --------------- | --------------------------------------------------------------------------- |
 | Dev (Storybook) | `npm dev` or `npm storybook` (port 6006)                                    |
-| Build           | `npm build` (Rollup → CJS + ESM + DTS in `dist/`)                           |
+| Build           | `npm build` (Rollup → ESM + DTS in `dist/`)                                 |
 | Test            | `npm test` (Vitest, run mode)                                               |
 | Test with UI    | `npm test:ui`                                                               |
 | Test coverage   | `npm test:coverage` (80% threshold for branches/functions/lines/statements) |
@@ -21,6 +21,7 @@ Entangle UI is a React component library for professional editor interfaces (3D 
 | Type check      | `npm type-check`                                                            |
 | Format          | `npm format`                                                                |
 | Format check    | `npm format:check`                                                          |
+| Bundle size     | `npm size` (size-limit)                                                     |
 
 ## Architecture
 
@@ -77,10 +78,15 @@ ComponentName/
 
 ## Build System
 
-- **Rollup** produces CJS (`dist/index.js`), ESM (`dist/index.esm.js`), and types (`dist/index.d.ts`)
+- **Rollup** produces ESM modules (`dist/esm/`) with `preserveModules` and types (`dist/types/`)
+- **No CJS output** — package is ESM-only (`"type": "module"`)
+- **Tree-shakeable**: `sideEffects: false` + `preserveModules` + `/*#__PURE__*/` annotations
+- **Build config**: `tsconfig.build.json` (extends `tsconfig.json`, excludes tests/stories)
 - **Vite** is only used for Storybook dev server, not library builds
-- Externals: react, react-dom, @base-ui/react
+- Externals: react, react-dom, react/jsx-runtime, @emotion/react, @emotion/styled, @base-ui-components/react, @floating-ui/react
 - Peer deps: React 19.1+, @emotion/react 11+, @emotion/styled 11+
+- Deep imports: `entangle-ui/palettes` available via `"exports"` field
+- Size guard: `npm run size` (size-limit)
 
 ## Storybook
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "entangle-ui",
-  "version": "0.1.0-alpha.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "entangle-ui",
-      "version": "0.1.0-alpha.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@base-ui-components/react": "^1.0.0-beta.0",
@@ -19,7 +19,9 @@
         "@changesets/cli": "^2.29.8",
         "@eslint/js": "^9.27.0",
         "@rollup/plugin-alias": "^5.1.1",
+        "@rollup/plugin-node-resolve": "^16.0.3",
         "@rollup/plugin-typescript": "^12.1.2",
+        "@size-limit/preset-small-lib": "^12.0.0",
         "@storybook/addon-docs": "^9.0.6",
         "@storybook/addon-onboarding": "^9.0.6",
         "@storybook/addon-themes": "^9.0.6",
@@ -45,6 +47,8 @@
         "react-dom": "^19.1.0",
         "rollup": "^4.41.0",
         "rollup-plugin-dts": "^6.2.1",
+        "rollup-plugin-preserve-directives": "^0.4.0",
+        "size-limit": "^12.0.0",
         "storybook": "^9.0.6",
         "typescript": "^5.8.3",
         "vite": "^6.3.5",
@@ -1398,6 +1402,23 @@
         "node": ">=18"
       }
     },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/sunos-x64": {
       "version": "0.25.5",
       "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.5.tgz",
@@ -2147,6 +2168,38 @@
         }
       }
     },
+    "node_modules/@rollup/plugin-node-resolve": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-16.0.3.tgz",
+      "integrity": "sha512-lUYM3UBGuM93CnMPG1YocWu7X802BrNF3jW2zny5gQyLQgRFJhV1Sq0Zi74+dh/6NBx1DxFC4b4GXg9wUCG5Qg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "@types/resolve": "1.20.2",
+        "deepmerge": "^4.2.2",
+        "is-module": "^1.0.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.78.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-node-resolve/node_modules/@types/resolve": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rollup/plugin-typescript": {
       "version": "12.1.2",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-12.1.2.tgz",
@@ -2476,6 +2529,537 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@size-limit/esbuild": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@size-limit/esbuild/-/esbuild-12.0.0.tgz",
+      "integrity": "sha512-r9i+HrtunIu7wAPtqD3t4DqfYin3kxPoMAv8cidkzlCS69IYCe3EG2UbQa10AdvQyaHTEK+MPkr9ifUd3W29og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "nanoid": "^5.1.6"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "size-limit": "12.0.0"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/nanoid": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.6.tgz",
+      "integrity": "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/@size-limit/file": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@size-limit/file/-/file-12.0.0.tgz",
+      "integrity": "sha512-OzKYpDzWJ2jo6cAIzVsaPuvzZTmMLDoVCViEvsctmImxpXzwJZcuBEpPohFKKdgVdZuNTU8WstmvywPq55Njdw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "size-limit": "12.0.0"
+      }
+    },
+    "node_modules/@size-limit/preset-small-lib": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@size-limit/preset-small-lib/-/preset-small-lib-12.0.0.tgz",
+      "integrity": "sha512-HHHVQjZmj+8vg7qsHs1dd3Hmn8ygUsE5O2CfxnbCbHOGyUw7VodZGERh/+5ogVrF2DYza/DIo2PnCJZZETdTRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@size-limit/esbuild": "12.0.0",
+        "@size-limit/file": "12.0.0",
+        "size-limit": "12.0.0"
+      },
+      "peerDependencies": {
+        "size-limit": "12.0.0"
+      }
     },
     "node_modules/@storybook/addon-docs": {
       "version": "9.0.6",
@@ -3625,6 +4209,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bytes-iec": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bytes-iec/-/bytes-iec-3.1.1.tgz",
+      "integrity": "sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -3893,6 +4487,16 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/define-lazy-prop": {
       "version": "2.0.0",
@@ -4452,11 +5056,14 @@
       }
     },
     "node_modules/fdir": {
-      "version": "6.4.5",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.5.tgz",
-      "integrity": "sha512-4BG7puHpVsIYxZUbiUE3RqGloLaSSwzYie5jvasC4LWuBWzZawynvYouhjbQKw2JuIGYdm0DzIxl8iVidKlUEw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -4919,6 +5526,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -5194,6 +5808,19 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -5428,6 +6055,16 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nanospinner": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/nanospinner/-/nanospinner-1.2.2.tgz",
+      "integrity": "sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.1.1"
       }
     },
     "node_modules/natural-compare": {
@@ -5748,9 +6385,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6177,6 +6814,20 @@
         "typescript": "^4.5 || ^5.0"
       }
     },
+    "node_modules/rollup-plugin-preserve-directives": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-preserve-directives/-/rollup-plugin-preserve-directives-0.4.0.tgz",
+      "integrity": "sha512-gx4nBxYm5BysmEQS+e2tAMrtFxrGvk+Pe5ppafRibQi0zlW7VYAbEGk6IKDw9sJGPdFWgVTE0o4BU4cdG0Fylg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.1.0",
+        "magic-string": "^0.30.5"
+      },
+      "peerDependencies": {
+        "rollup": "2.x || 3.x || 4.x"
+      }
+    },
     "node_modules/rollup/node_modules/@types/estree": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
@@ -6310,6 +6961,34 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/size-limit": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/size-limit/-/size-limit-12.0.0.tgz",
+      "integrity": "sha512-JBG8dioIs0m2kHOhs9jD6E/tZKD08vmbf2bfqj/rJyNWqJxk/ZcakixjhYtsqdbi+AKVbfPkt3g2RRZiKaizYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes-iec": "^3.1.1",
+        "lilconfig": "^3.1.3",
+        "nanospinner": "^1.2.2",
+        "picocolors": "^1.1.1",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "size-limit": "bin.js"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "jiti": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
       }
     },
     "node_modules/slash": {
@@ -6702,14 +7381,14 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": ">=12.0.0"

--- a/package.json
+++ b/package.json
@@ -2,10 +2,22 @@
   "name": "entangle-ui",
   "version": "0.2.0",
   "type": "module",
+  "sideEffects": false,
   "description": "A specialized React component library for building professional editor interfaces",
-  "main": "dist/index.js",
-  "module": "dist/index.esm.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/esm/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "default": "./dist/esm/index.js"
+    },
+    "./palettes": {
+      "types": "./dist/types/palettes.d.ts",
+      "default": "./dist/esm/palettes.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist",
     "README.md",
@@ -32,7 +44,8 @@
     "storybook": "storybook dev -p 6006",
     "changeset": "changeset",
     "version-packages": "changeset version",
-    "release": "changeset publish"
+    "release": "changeset publish",
+    "size": "size-limit"
   },
   "keywords": [
     "react",
@@ -63,8 +76,6 @@
   },
   "dependencies": {
     "@base-ui-components/react": "^1.0.0-beta.0",
-    "@emotion/react": "^11.0.0",
-    "@emotion/styled": "^11.0.0",
     "@floating-ui/react": "^0.27.17"
   },
   "devDependencies": {
@@ -72,7 +83,9 @@
     "@changesets/cli": "^2.29.8",
     "@eslint/js": "^9.27.0",
     "@rollup/plugin-alias": "^5.1.1",
+    "@rollup/plugin-node-resolve": "^16.0.3",
     "@rollup/plugin-typescript": "^12.1.2",
+    "@size-limit/preset-small-lib": "^12.0.0",
     "@storybook/addon-docs": "^9.0.6",
     "@storybook/addon-onboarding": "^9.0.6",
     "@storybook/addon-themes": "^9.0.6",
@@ -98,6 +111,8 @@
     "react-dom": "^19.1.0",
     "rollup": "^4.41.0",
     "rollup-plugin-dts": "^6.2.1",
+    "rollup-plugin-preserve-directives": "^0.4.0",
+    "size-limit": "^12.0.0",
     "storybook": "^9.0.6",
     "typescript": "^5.8.3",
     "vite": "^6.3.5",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,36 +1,88 @@
+import { resolve } from 'path';
+import { fileURLToPath } from 'url';
 import typescript from '@rollup/plugin-typescript';
+import alias from '@rollup/plugin-alias';
+import nodeResolve from '@rollup/plugin-node-resolve';
+import preserveDirectives from 'rollup-plugin-preserve-directives';
 import dts from 'rollup-plugin-dts';
 
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+
+/**
+ * External dependency matcher.
+ * Matches exact package names AND deep imports (e.g. '@emotion/react/jsx-runtime').
+ */
+const EXTERNAL_PACKAGES = [
+  'react',
+  'react-dom',
+  'react/jsx-runtime',
+  '@emotion/react',
+  '@emotion/styled',
+  '@emotion/react/jsx-runtime',
+  '@base-ui-components/react',
+  '@floating-ui/react',
+];
+
+const isExternal = id =>
+  EXTERNAL_PACKAGES.some(pkg => id === pkg || id.startsWith(pkg + '/'));
+
+const aliasPlugin = alias({
+  entries: [{ find: '@', replacement: resolve(__dirname, 'src') }],
+});
+
+/** Suppress MODULE_LEVEL_DIRECTIVE warnings from preserveDirectives */
+const onwarn = (warning, warn) => {
+  if (warning.code === 'MODULE_LEVEL_DIRECTIVE') return;
+  warn(warning);
+};
+
 export default [
+  // ESM build — preserveModules for tree-shaking
   {
-    input: 'src/index.ts',
-    output: [
-      {
-        file: 'dist/index.js',
-        format: 'cjs',
-        sourcemap: true,
-      },
-      {
-        file: 'dist/index.esm.js',
-        format: 'esm',
-        sourcemap: true,
-      },
-    ],
-    external: ['react', 'react-dom', '@base-ui/react'],
-    plugins: [
-      typescript({
-        tsconfig: './tsconfig.json',
-        declaration: false,
-      }),
-    ],
-  },
-  {
-    input: 'src/index.ts',
-    output: {
-      file: 'dist/index.d.ts',
-      format: 'esm',
+    input: {
+      index: 'src/index.ts',
+      palettes: 'src/palettes.ts',
     },
-    external: ['react', 'react-dom', '@base-ui/react'],
-    plugins: [dts()],
+    output: {
+      dir: 'dist/esm',
+      format: 'esm',
+      sourcemap: true,
+      preserveModules: true,
+      preserveModulesRoot: 'src',
+      entryFileNames: '[name].js',
+    },
+    external: isExternal,
+    plugins: [
+      aliasPlugin,
+      nodeResolve({ extensions: ['.ts', '.tsx', '.js', '.jsx'] }),
+      typescript({
+        tsconfig: './tsconfig.build.json',
+        declaration: false,
+        outDir: 'dist/esm',
+      }),
+      preserveDirectives(),
+    ],
+    onwarn,
+  },
+
+  // Type declarations — preserveModules for per-file .d.ts
+  {
+    input: {
+      index: 'src/index.ts',
+      palettes: 'src/palettes.ts',
+    },
+    output: {
+      dir: 'dist/types',
+      format: 'esm',
+      preserveModules: true,
+      preserveModulesRoot: 'src',
+    },
+    external: isExternal,
+    plugins: [
+      alias({
+        entries: [{ find: '@', replacement: resolve(__dirname, 'src') }],
+      }),
+      dts({ tsconfig: './tsconfig.build.json' }),
+    ],
   },
 ];

--- a/src/components/controls/ColorPicker/ColorSwatch.tsx
+++ b/src/components/controls/ColorPicker/ColorSwatch.tsx
@@ -67,7 +67,7 @@ const StyledSwatchColor = styled.span`
   border-radius: inherit;
 `;
 
-export const ColorSwatch = React.memo<ColorSwatchProps>(
+export const ColorSwatch = /*#__PURE__*/ React.memo<ColorSwatchProps>(
   ({
     color,
     size = 'md',

--- a/src/components/editor/PropertyInspector/PropertyPanel.tsx
+++ b/src/components/editor/PropertyInspector/PropertyPanel.tsx
@@ -16,9 +16,8 @@ import type {
 
 // --- Context ---
 
-const PropertyPanelContext = createContext<PropertyPanelContextValue | null>(
-  null
-);
+const PropertyPanelContext =
+  /*#__PURE__*/ createContext<PropertyPanelContextValue | null>(null);
 
 /**
  * Returns the PropertyPanel context value, or null if not inside a PropertyPanel.

--- a/src/components/feedback/Dialog/Dialog.tsx
+++ b/src/components/feedback/Dialog/Dialog.tsx
@@ -13,7 +13,9 @@ import { useFocusTrap } from './useFocusTrap';
 
 // --- Context ---
 
-const DialogContext = createContext<DialogContextValue | null>(null);
+const DialogContext = /*#__PURE__*/ createContext<DialogContextValue | null>(
+  null
+);
 
 export function useDialogContext(): DialogContextValue {
   const ctx = useContext(DialogContext);

--- a/src/components/feedback/Toast/ToastProvider.tsx
+++ b/src/components/feedback/Toast/ToastProvider.tsx
@@ -17,7 +17,8 @@ export interface ToastContextValue {
   defaultDuration: number;
 }
 
-export const ToastContext = createContext<ToastContextValue | null>(null);
+export const ToastContext =
+  /*#__PURE__*/ createContext<ToastContextValue | null>(null);
 
 // --- Reducer ---
 

--- a/src/components/form/FormHelperText.tsx
+++ b/src/components/form/FormHelperText.tsx
@@ -50,7 +50,7 @@ const StyledHelperText = styled.div<{
  * <FormHelperText error>{usernameError}</FormHelperText>
  * ```
  */
-export const FormHelperText = React.memo<FormHelperTextProps>(
+export const FormHelperText = /*#__PURE__*/ React.memo<FormHelperTextProps>(
   ({ children, error = false, className, style, css, ref, ...rest }) => {
     return (
       <StyledHelperText

--- a/src/components/form/FormLabel.tsx
+++ b/src/components/form/FormLabel.tsx
@@ -67,7 +67,7 @@ const RequiredIndicator = styled.span`
  * <Input id="name-input" />
  * ```
  */
-export const FormLabel = React.memo<FormLabelProps>(
+export const FormLabel = /*#__PURE__*/ React.memo<FormLabelProps>(
   ({
     children,
     htmlFor,

--- a/src/components/form/InputWrapper.tsx
+++ b/src/components/form/InputWrapper.tsx
@@ -137,7 +137,7 @@ export const StyledInputWrapper = styled.div<StyledInputWrapperProps>`
  * </InputWrapper>
  * ```
  */
-export const InputWrapper = React.memo<InputWrapperProps>(
+export const InputWrapper = /*#__PURE__*/ React.memo<InputWrapperProps>(
   ({
     children,
     size = 'md',

--- a/src/components/layout/Accordion/Accordion.tsx
+++ b/src/components/layout/Accordion/Accordion.tsx
@@ -15,10 +15,10 @@ import type {
 
 // --- Contexts ---
 
-const AccordionContext = createContext<AccordionContextValue | null>(null);
-const AccordionItemContext = createContext<AccordionItemContextValue | null>(
-  null
-);
+const AccordionContext =
+  /*#__PURE__*/ createContext<AccordionContextValue | null>(null);
+const AccordionItemContext =
+  /*#__PURE__*/ createContext<AccordionItemContextValue | null>(null);
 
 export function useAccordionContext(): AccordionContextValue {
   const ctx = useContext(AccordionContext);

--- a/src/components/layout/PanelSurface/PanelSurface.tsx
+++ b/src/components/layout/PanelSurface/PanelSurface.tsx
@@ -11,9 +11,10 @@ import type {
   PanelSurfaceSize,
 } from './PanelSurface.types';
 
-const PanelSurfaceContext = createContext<PanelSurfaceContextValue>({
-  size: 'md',
-});
+const PanelSurfaceContext =
+  /*#__PURE__*/ createContext<PanelSurfaceContextValue>({
+    size: 'md',
+  });
 
 const usePanelSurface = () => useContext(PanelSurfaceContext);
 
@@ -247,7 +248,7 @@ const PanelSurfaceRoot: React.FC<PanelSurfaceProps> = ({
 
 PanelSurfaceRoot.displayName = 'PanelSurface';
 
-export const PanelSurface = Object.assign(PanelSurfaceRoot, {
+export const PanelSurface = /*#__PURE__*/ Object.assign(PanelSurfaceRoot, {
   Header: PanelSurfaceHeader,
   Body: PanelSurfaceBody,
   Footer: PanelSurfaceFooter,

--- a/src/components/layout/Spacer/Spacer.tsx
+++ b/src/components/layout/Spacer/Spacer.tsx
@@ -101,7 +101,7 @@ const StyledSpacer = styled.div<StyledSpacerProps>`
  * </Stack>
  * ```
  */
-export const Spacer = React.memo<SpacerProps>(
+export const Spacer = /*#__PURE__*/ React.memo<SpacerProps>(
   ({ size, className, testId, css, style, ref, ...htmlProps }) => {
     return (
       <StyledSpacer

--- a/src/components/navigation/Tabs/Tabs.tsx
+++ b/src/components/navigation/Tabs/Tabs.tsx
@@ -12,7 +12,7 @@ import type { TabsContextValue, TabsProps } from './Tabs.types';
 
 // --- Context ---
 
-const TabsContext = createContext<TabsContextValue | null>(null);
+const TabsContext = /*#__PURE__*/ createContext<TabsContextValue | null>(null);
 
 export function useTabsContext(): TabsContextValue {
   const ctx = useContext(TabsContext);

--- a/src/components/primitives/BaseButton/BaseButton.tsx
+++ b/src/components/primitives/BaseButton/BaseButton.tsx
@@ -14,28 +14,29 @@ export interface BaseButtonProps
   'data-testid'?: string;
 }
 
-export const BaseButton = forwardRef<HTMLButtonElement, BaseButtonProps>(
-  ({ className, disabled = false, children, ...props }, ref) => {
-    return (
-      <button
-        ref={ref}
-        className={cn(
-          // Reset only some styles, not all
-          'bg-transparent p-0 m-0',
-          // Base interactive styles
-          'cursor-pointer select-none',
-          'focus:outline-none',
-          // Disabled state
-          disabled && 'cursor-not-allowed',
-          className
-        )}
-        disabled={disabled}
-        {...props}
-      >
-        {children}
-      </button>
-    );
-  }
-);
+export const BaseButton = /*#__PURE__*/ forwardRef<
+  HTMLButtonElement,
+  BaseButtonProps
+>(({ className, disabled = false, children, ...props }, ref) => {
+  return (
+    <button
+      ref={ref}
+      className={cn(
+        // Reset only some styles, not all
+        'bg-transparent p-0 m-0',
+        // Base interactive styles
+        'cursor-pointer select-none',
+        'focus:outline-none',
+        // Disabled state
+        disabled && 'cursor-not-allowed',
+        className
+      )}
+      disabled={disabled}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+});
 
 BaseButton.displayName = 'BaseButton';

--- a/src/components/primitives/Button/Button.tsx
+++ b/src/components/primitives/Button/Button.tsx
@@ -269,7 +269,7 @@ const IconWrapper = styled.span`
  * </Button>
  * ```
  */
-export const Button = React.memo<ButtonProps>(
+export const Button = /*#__PURE__*/ React.memo<ButtonProps>(
   ({
     children,
     className,

--- a/src/components/primitives/Checkbox/CheckboxGroup.tsx
+++ b/src/components/primitives/Checkbox/CheckboxGroup.tsx
@@ -9,7 +9,7 @@ import type {
 } from './Checkbox.types';
 
 export const CheckboxGroupContext =
-  createContext<CheckboxGroupContextValue | null>(null);
+  /*#__PURE__*/ createContext<CheckboxGroupContextValue | null>(null);
 
 interface StyledGroupProps {
   $direction: 'row' | 'column';

--- a/src/components/primitives/Icon/Icon.tsx
+++ b/src/components/primitives/Icon/Icon.tsx
@@ -100,7 +100,7 @@ const StyledSVG = styled.svg<StyledSVGProps>`
   ${props => processCss(props.$css, props.theme)}
 `;
 
-export const Icon = React.memo<IconProps>(
+export const Icon = /*#__PURE__*/ React.memo<IconProps>(
   ({
     children,
     size = 'md',

--- a/src/components/primitives/IconButton/IconButton.tsx
+++ b/src/components/primitives/IconButton/IconButton.tsx
@@ -328,7 +328,7 @@ const LoadingSpinner = styled.div<{ $size: IconButtonSize }>`
  * </IconButton>
  * ```
  */
-export const IconButton = React.memo<IconButtonProps>(
+export const IconButton = /*#__PURE__*/ React.memo<IconButtonProps>(
   ({
     children,
     className,

--- a/src/components/primitives/Paper/Paper.tsx
+++ b/src/components/primitives/Paper/Paper.tsx
@@ -252,7 +252,7 @@ const StyledPaper = styled.div<StyledPaperProps>`
  * </Paper>
  * ```
  */
-export const Paper = React.memo<PaperProps>(
+export const Paper = /*#__PURE__*/ React.memo<PaperProps>(
   ({
     children,
     elevation = 1,

--- a/src/components/primitives/Popover/Popover.tsx
+++ b/src/components/primitives/Popover/Popover.tsx
@@ -22,7 +22,9 @@ import type { PopoverContextValue, PopoverProps } from './Popover.types';
 
 // --- Context ---
 
-const PopoverContext = createContext<PopoverContextValue | null>(null);
+const PopoverContext = /*#__PURE__*/ createContext<PopoverContextValue | null>(
+  null
+);
 
 export function usePopoverContext(): PopoverContextValue {
   const ctx = useContext(PopoverContext);

--- a/src/components/primitives/Text/Text.tsx
+++ b/src/components/primitives/Text/Text.tsx
@@ -337,7 +337,7 @@ const StyledText = styled.span<StyledTextProps>`
  * <Text as="label" variant="caption">Form label</Text>
  * ```
  */
-export const Text = React.memo<TextProps>(
+export const Text = /*#__PURE__*/ React.memo<TextProps>(
   ({
     children,
     as = 'span',

--- a/src/components/shell/AppShell/AppShell.tsx
+++ b/src/components/shell/AppShell/AppShell.tsx
@@ -20,7 +20,7 @@ import type {
 
 // --- Context ---
 
-const AppShellContext = createContext<AppShellContextValue>({
+const AppShellContext = /*#__PURE__*/ createContext<AppShellContextValue>({
   isToolbarVisible: () => true,
   setToolbarVisible: () => {},
   topChromeSeparator: 'border',
@@ -338,7 +338,7 @@ AppShellRoot.displayName = 'AppShell';
 
 // --- Compound Component ---
 
-export const AppShell = Object.assign(AppShellRoot, {
+export const AppShell = /*#__PURE__*/ Object.assign(AppShellRoot, {
   MenuBar: MenuBarSlot,
   Toolbar: ToolbarSlot,
   Dock: DockSlot,

--- a/src/components/shell/FloatingPanel/FloatingPanel.tsx
+++ b/src/components/shell/FloatingPanel/FloatingPanel.tsx
@@ -22,7 +22,7 @@ import type {
 // --- FloatingManager Context ---
 
 const FloatingManagerContext =
-  createContext<FloatingManagerContextValue | null>(null);
+  /*#__PURE__*/ createContext<FloatingManagerContextValue | null>(null);
 
 const useFloatingManager = () => useContext(FloatingManagerContext);
 

--- a/src/components/shell/MenuBar/MenuBar.tsx
+++ b/src/components/shell/MenuBar/MenuBar.tsx
@@ -23,7 +23,7 @@ import type {
 
 // --- Context ---
 
-const MenuBarContext = createContext<MenuBarContextValue>({
+const MenuBarContext = /*#__PURE__*/ createContext<MenuBarContextValue>({
   size: 'md',
   menuOffset: 2,
   openMenuId: null,
@@ -598,7 +598,7 @@ MenuBarRoot.displayName = 'MenuBar';
 
 // --- Compound Component ---
 
-export const MenuBar = Object.assign(MenuBarRoot, {
+export const MenuBar = /*#__PURE__*/ Object.assign(MenuBarRoot, {
   Menu: MenuBarMenu,
   Item: MenuBarItem,
   Sub: MenuBarSub,

--- a/src/components/shell/StatusBar/StatusBar.tsx
+++ b/src/components/shell/StatusBar/StatusBar.tsx
@@ -12,7 +12,9 @@ import type {
   StatusBarSectionSide,
 } from './StatusBar.types';
 
-const StatusBarContext = createContext<StatusBarContextValue>({ size: 'sm' });
+const StatusBarContext = /*#__PURE__*/ createContext<StatusBarContextValue>({
+  size: 'sm',
+});
 
 const useStatusBar = () => useContext(StatusBarContext);
 
@@ -131,7 +133,7 @@ const StyledBadge = styled.span<{ $dot: boolean }>`
 
 // --- Sub-components ---
 
-const StatusBarSection = React.memo<StatusBarSectionProps>(
+const StatusBarSection = /*#__PURE__*/ React.memo<StatusBarSectionProps>(
   ({
     $side = 'left',
     children,
@@ -160,7 +162,7 @@ const StatusBarSection = React.memo<StatusBarSectionProps>(
 
 StatusBarSection.displayName = 'StatusBar.Section';
 
-const StatusBarItem = React.memo<StatusBarItemProps>(
+const StatusBarItem = /*#__PURE__*/ React.memo<StatusBarItemProps>(
   ({
     onClick,
     icon,
@@ -265,7 +267,7 @@ StatusBarRoot.displayName = 'StatusBar';
 
 // --- Compound Component ---
 
-export const StatusBar = Object.assign(StatusBarRoot, {
+export const StatusBar = /*#__PURE__*/ Object.assign(StatusBarRoot, {
   Section: StatusBarSection,
   Item: StatusBarItem,
 });

--- a/src/components/shell/Toolbar/Toolbar.tsx
+++ b/src/components/shell/Toolbar/Toolbar.tsx
@@ -20,7 +20,7 @@ import type {
   ToolbarSize,
 } from './Toolbar.types';
 
-const ToolbarContext = createContext<ToolbarContextValue>({
+const ToolbarContext = /*#__PURE__*/ createContext<ToolbarContextValue>({
   orientation: 'horizontal',
   size: 'md',
 });
@@ -142,7 +142,7 @@ function focusableItems(container: HTMLElement): HTMLElement[] {
 
 // --- Sub-components ---
 
-const ToolbarButton = React.memo<ToolbarButtonProps>(
+const ToolbarButton = /*#__PURE__*/ React.memo<ToolbarButtonProps>(
   ({
     onClick,
     icon,
@@ -184,7 +184,7 @@ const ToolbarButton = React.memo<ToolbarButtonProps>(
 
 ToolbarButton.displayName = 'Toolbar.Button';
 
-const ToolbarToggle = React.memo<ToolbarToggleProps>(
+const ToolbarToggle = /*#__PURE__*/ React.memo<ToolbarToggleProps>(
   ({
     pressed,
     onPressedChange,
@@ -228,7 +228,7 @@ const ToolbarToggle = React.memo<ToolbarToggleProps>(
 
 ToolbarToggle.displayName = 'Toolbar.Toggle';
 
-const ToolbarGroup = React.memo<ToolbarGroupProps>(
+const ToolbarGroup = /*#__PURE__*/ React.memo<ToolbarGroupProps>(
   ({ children, className, style, testId, css, ref, ...rest }) => {
     const { orientation } = useToolbar();
 
@@ -251,7 +251,7 @@ const ToolbarGroup = React.memo<ToolbarGroupProps>(
 
 ToolbarGroup.displayName = 'Toolbar.Group';
 
-const ToolbarSeparator = React.memo<ToolbarSeparatorProps>(
+const ToolbarSeparator = /*#__PURE__*/ React.memo<ToolbarSeparatorProps>(
   ({ className, style, testId, css, ref, ...rest }) => {
     const { orientation } = useToolbar();
     return (
@@ -274,7 +274,7 @@ const ToolbarSeparator = React.memo<ToolbarSeparatorProps>(
 
 ToolbarSeparator.displayName = 'Toolbar.Separator';
 
-const ToolbarSpacer = React.memo<ToolbarSpacerProps>(
+const ToolbarSpacer = /*#__PURE__*/ React.memo<ToolbarSpacerProps>(
   ({ className, style, testId, css, ref, ...rest }) => {
     return (
       <StyledSpacer
@@ -397,7 +397,7 @@ ToolbarRoot.displayName = 'Toolbar';
 
 // --- Compound Component ---
 
-export const Toolbar = Object.assign(ToolbarRoot, {
+export const Toolbar = /*#__PURE__*/ Object.assign(ToolbarRoot, {
   Button: ToolbarButton,
   Toggle: ToolbarToggle,
   Group: ToolbarGroup,

--- a/src/context/KeyboardContext.tsx
+++ b/src/context/KeyboardContext.tsx
@@ -4,13 +4,13 @@ import { createContext, useContext, memo, useEffect, useCallback } from 'react';
 import { useKeyboard, isKeyPressed } from '@/hooks/useKeyboard';
 import type { KeyboardState, AllKeys } from '@/hooks/useKeyboard';
 
-const KeyboardContext = createContext<KeyboardState | null>(null);
+const KeyboardContext = /*#__PURE__*/ createContext<KeyboardState | null>(null);
 
 export interface KeyboardContextProviderProps {
   children: React.ReactNode;
 }
 
-export const KeyboardContextProvider = memo(
+export const KeyboardContextProvider = /*#__PURE__*/ memo(
   ({ children }: KeyboardContextProviderProps) => {
     const keyboardState = useKeyboard();
     return (

--- a/src/palettes.ts
+++ b/src/palettes.ts
@@ -1,0 +1,18 @@
+// Standalone palette entry point for 'entangle-ui/palettes'
+export {
+  MATERIAL_PALETTE,
+  TAILWIND_PALETTE,
+  PASTEL_PALETTE,
+  EARTH_PALETTE,
+  NEON_PALETTE,
+  MONOCHROME_PALETTE,
+  SKIN_TONES_PALETTE,
+  VINTAGE_PALETTE,
+  PROFESSIONAL_PALETTES,
+} from '@/components/controls/ColorPicker/palettes';
+
+export type {
+  Palette,
+  PaletteColor,
+  PaletteShade,
+} from '@/components/controls/ColorPicker/palettes';

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,21 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": true,
+    "outDir": "dist",
+    "noEmit": false,
+    "types": []
+  },
+  "include": ["src/**/*"],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/*.test.*",
+    "src/**/*.stories.*",
+    "src/**/*.spec.*",
+    "src/tests/**",
+    "scripts"
+  ]
+}


### PR DESCRIPTION
- Replace monolithic single-file bundle with per-module ESM output (dist/esm/)
- Drop CJS output — ESM-only package targeting React 19+ / modern bundlers
- Add sideEffects: false and exports field to package.json
- Fix externals: add @emotion/react, @emotion/styled, @floating-ui/react, react/jsx-runtime; fix @base-ui/react → @base-ui-components/react
- Remove @emotion/react and @emotion/styled from dependencies (keep in peerDependencies only to prevent duplicate instances)
- Add /*#__PURE__*/ annotations on Object.assign, createContext, React.memo, and forwardRef calls for optimal tree-shaking
- Add entangle-ui/palettes deep import entry point
- Add size-limit bundle size guards
- Create tsconfig.build.json excluding tests/stories from build output