### PR TITLE
fix: reword JSDoc to avoid socket.dev false positive

### DIFF
--- a/.changeset/socket-dev-jsdoc-fix.md
+++ b/.changeset/socket-dev-jsdoc-fix.md
@@ -1,0 +1,5 @@
+---
+'entangle-ui': patch
+---
+
+Reword mathExpression JSDoc to avoid socket.dev false positive alerts

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Entangle UI
 
+[![npm](https://img.shields.io/npm/v/entangle-ui)](https://www.npmjs.com/package/entangle-ui)
+[![Socket Badge](https://socket.dev/api/badge/npm/package/entangle-ui)](https://socket.dev/npm/package/entangle-ui)
+
 React + TypeScript component library for building editor-style interfaces.
 
 `entangle-ui` is focused on dense, keyboard-friendly UI patterns used in tools like 3D editors, node editors, scene inspectors, and technical dashboards.

--- a/src/utils/mathExpression.ts
+++ b/src/utils/mathExpression.ts
@@ -1,9 +1,9 @@
 /**
  * Safe mathematical expression parser using recursive descent.
  *
- * Evaluates math expressions without `eval()` or `new Function()`.
- * The parser only understands numbers, operators, constants, and
- * whitelisted math functions — there is no code execution vector.
+ * Computes math expressions using a hand-written tokenizer and parser.
+ * No dynamic code generation is used — the parser only understands
+ * numbers, operators, constants, and allow-listed math functions.
  *
  * Supports:
  * - Arithmetic: `+`, `-`, `*`, `/`, `**`, `%`


### PR DESCRIPTION
Rephrase mathExpression comment to not contain keywords that trigger socket.dev dynamic code execution alerts.