### PR TITLE
feat(alert): add Alert component for persistent inline status banners

### DIFF
--- a/.changeset/alert-component.md
+++ b/.changeset/alert-component.md
@@ -1,0 +1,15 @@
+---
+'entangle-ui': minor
+---
+
+Add `Alert` component for persistent inline status banners — read-only
+notices, expired-credentials warnings, unsaved-changes banners, and similar
+in-layout messages. Five semantic variants (`info`, `success`, `warning`,
+`error`, `neutral`) drive the color and the default icon, with three visual
+treatments: `subtle` (default), `solid`, and `outline`. Provide `onClose`
+to render a dismiss button. Ships a compound API — `Alert.Title`,
+`Alert.Description`, `Alert.Actions` — also exported as standalone
+`AlertTitle`, `AlertDescription`, `AlertActions`. ARIA roles are derived
+from the variant (`alert` for error/warning, `status` for info/success,
+`region` for neutral). For transient confirmations like "File saved", reach
+for `useToast` instead.

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -152,6 +152,7 @@ export default defineConfig({
               label: 'Feedback',
               collapsed: false,
               items: [
+                { label: 'Alert', slug: 'components/feedback/alert' },
                 { label: 'Dialog', slug: 'components/feedback/dialog' },
                 {
                   label: 'EmptyState',

--- a/docs-site/src/components/demos/feedback/AlertDemo.tsx
+++ b/docs-site/src/components/demos/feedback/AlertDemo.tsx
@@ -1,0 +1,173 @@
+import { useState } from 'react';
+import DemoWrapper from '../DemoWrapper';
+import { Alert } from '@/components/feedback';
+import { Button } from '@/components/primitives';
+import { Stack } from '@/components/layout';
+
+export default function AlertDemo() {
+  return (
+    <DemoWrapper>
+      <Stack gap={3} style={{ width: '100%', maxWidth: 480 }}>
+        <Alert variant="info" title="Heads up">
+          A new render has been queued. You can keep editing while it runs.
+        </Alert>
+        <Alert variant="success" title="Saved">
+          All overrides have been written to disk.
+        </Alert>
+        <Alert variant="warning" title="Read-only mode">
+          Switch to edit mode to make changes.
+        </Alert>
+        <Alert variant="error" title="Connection lost">
+          We can&apos;t reach the render farm. Retry once you&apos;re back
+          online.
+        </Alert>
+        <Alert variant="neutral" title="Note">
+          Drag a node from the library to start a new graph.
+        </Alert>
+      </Stack>
+    </DemoWrapper>
+  );
+}
+
+export function AlertVariants() {
+  return (
+    <DemoWrapper>
+      <Stack gap={3} style={{ width: '100%', maxWidth: 480 }}>
+        <Alert variant="info">Informational alert.</Alert>
+        <Alert variant="success">Success alert.</Alert>
+        <Alert variant="warning">Warning alert.</Alert>
+        <Alert variant="error">Error alert.</Alert>
+        <Alert variant="neutral">Neutral alert.</Alert>
+      </Stack>
+    </DemoWrapper>
+  );
+}
+
+export function AlertAppearances() {
+  return (
+    <DemoWrapper>
+      <Stack gap={3} style={{ width: '100%', maxWidth: 480 }}>
+        <Alert variant="info" appearance="subtle" title="Subtle">
+          Tinted background, faint border. Recommended default.
+        </Alert>
+        <Alert variant="info" appearance="solid" title="Solid">
+          Filled accent background. Use sparingly — high attention.
+        </Alert>
+        <Alert variant="info" appearance="outline" title="Outline">
+          Bordered, transparent background. Quietest treatment.
+        </Alert>
+      </Stack>
+    </DemoWrapper>
+  );
+}
+
+export function AlertWithoutIcon() {
+  return (
+    <DemoWrapper>
+      <div style={{ width: '100%', maxWidth: 480 }}>
+        <Alert variant="warning" icon={false} title="Read-only">
+          Switch to edit mode to make changes.
+        </Alert>
+      </div>
+    </DemoWrapper>
+  );
+}
+
+export function AlertDismissible() {
+  const [open, setOpen] = useState(true);
+  return (
+    <DemoWrapper>
+      <div style={{ width: '100%', maxWidth: 480 }}>
+        {open ? (
+          <Alert
+            variant="success"
+            title="Export complete"
+            onClose={() => setOpen(false)}
+          >
+            The scene was exported successfully.
+          </Alert>
+        ) : (
+          <Button onClick={() => setOpen(true)}>Restore alert</Button>
+        )}
+      </div>
+    </DemoWrapper>
+  );
+}
+
+export function AlertCompact() {
+  return (
+    <DemoWrapper>
+      <div style={{ width: '100%', maxWidth: 480 }}>
+        <Alert variant="info">Auto-save is on.</Alert>
+      </div>
+    </DemoWrapper>
+  );
+}
+
+export function AlertWithActions() {
+  return (
+    <DemoWrapper>
+      <div style={{ width: '100%', maxWidth: 480 }}>
+        <Alert variant="error" title="Couldn't reach the server">
+          <Alert.Description>
+            The request timed out after 30 seconds.
+          </Alert.Description>
+          <Alert.Actions align="right">
+            <Button variant="filled">Retry</Button>
+            <Button>Dismiss</Button>
+          </Alert.Actions>
+        </Alert>
+      </div>
+    </DemoWrapper>
+  );
+}
+
+export function AlertLongContent() {
+  return (
+    <DemoWrapper>
+      <div style={{ width: '100%', maxWidth: 520 }}>
+        <Alert variant="warning" title="Pending migration">
+          <Alert.Description>
+            The shader graph format changed in version 0.9. Existing graphs will
+            continue to load, but new features require the new schema.
+          </Alert.Description>
+          <Alert.Description style={{ marginTop: 8 }}>
+            Run{' '}
+            <code style={{ fontSize: 11 }}>npx entangle-ui migrate-graphs</code>{' '}
+            from the project root to upgrade in place. Original files are
+            written to <code style={{ fontSize: 11 }}>.entangle-backup/</code>{' '}
+            first.
+          </Alert.Description>
+        </Alert>
+      </div>
+    </DemoWrapper>
+  );
+}
+
+export function AlertReadOnlyFile() {
+  return (
+    <DemoWrapper>
+      <Stack gap={3} style={{ width: '100%', maxWidth: 360 }}>
+        <Alert variant="warning" title="Read-only file">
+          <Alert.Description>
+            <code style={{ fontSize: 11 }}>materials/asphalt.json</code> is
+            checked out by another user.
+          </Alert.Description>
+        </Alert>
+        <div
+          style={{
+            padding: 12,
+            border:
+              '1px solid color-mix(in srgb, var(--etui-color-border-default) 60%, transparent)',
+            borderRadius: 6,
+            background: 'var(--etui-color-bg-elevated)',
+            fontSize: 12,
+            color: 'var(--etui-color-text-muted)',
+          }}
+        >
+          Inspector is read-only.
+        </div>
+      </Stack>
+    </DemoWrapper>
+  );
+}

--- a/docs-site/src/content/docs/components/feedback/alert.mdx
+++ b/docs-site/src/content/docs/components/feedback/alert.mdx
@@ -1,0 +1,375 @@
+---
+title: Alert
+description: Persistent inline status banner with semantic variants, three appearances, optional close button, and a compound API for richer layouts.
+---
+
+import PropsTable from '../../../../components/PropsTable.astro';
+import ComponentPreview from '../../../../components/ComponentPreview.astro';
+import AlertDemo, {
+  AlertVariants,
+  AlertAppearances,
+  AlertWithoutIcon,
+  AlertDismissible,
+  AlertCompact,
+  AlertWithActions,
+  AlertLongContent,
+  AlertReadOnlyFile,
+} from '../../../../components/demos/feedback/AlertDemo';
+
+A persistent inline status banner. Use `Alert` for messages tied to the surrounding UI — a read-only file warning above an inspector, an expired-credentials notice on a settings panel, or an unsaved-changes banner. For transient confirmations like "File saved" or "Export complete", reach for [Toast](/components/feedback/toast) instead.
+
+<ComponentPreview title="Live Preview">
+  <AlertDemo client:only="react" />
+</ComponentPreview>
+
+## When to use
+
+- **Alert** — persistent inline status that the user reads while they work. Doesn't auto-dismiss. Sits in the layout.
+- **Toast** — transient confirmation that fades after a few seconds. Sits in an overlay corner. Use `useToast`.
+- **Dialog** — blocks the rest of the UI and demands a response.
+
+## Import
+
+```tsx
+import { Alert } from 'entangle-ui';
+```
+
+The compound members come along automatically:
+
+```tsx
+<Alert>
+  <Alert.Title>...</Alert.Title>
+  <Alert.Description>...</Alert.Description>
+  <Alert.Actions>...</Alert.Actions>
+</Alert>
+```
+
+If you'd rather destructure, the same components are also exported as named imports:
+
+```tsx
+import { Alert, AlertTitle, AlertDescription, AlertActions } from 'entangle-ui';
+```
+
+## Usage
+
+```tsx
+<Alert variant="warning" title="Read-only mode">
+  Switch to edit mode to make changes.
+</Alert>
+```
+
+A plain string in `children` is rendered as the description — no title needed for one-liners:
+
+```tsx
+<Alert variant="info">Auto-save is on.</Alert>
+```
+
+## Variants
+
+The `variant` prop drives the color and the default icon.
+
+<ComponentPreview title="Variants">
+  <AlertVariants client:only="react" />
+</ComponentPreview>
+
+| Variant   | Color token             | Default icon  | Role     |
+| --------- | ----------------------- | ------------- | -------- |
+| `info`    | `colors.accent.primary` | `InfoIcon`    | `status` |
+| `success` | `colors.accent.success` | `CheckIcon`   | `status` |
+| `warning` | `colors.accent.warning` | `WarningIcon` | `alert`  |
+| `error`   | `colors.accent.error`   | `ErrorIcon`   | `alert`  |
+| `neutral` | `colors.text.muted`     | _(none)_      | `region` |
+
+```tsx
+<Alert variant="info" />
+<Alert variant="success" />
+<Alert variant="warning" />
+<Alert variant="error" />
+<Alert variant="neutral" />
+```
+
+## Appearances
+
+Three visual treatments. `subtle` is the default — and the right pick most of the time.
+
+<ComponentPreview title="Appearances">
+  <AlertAppearances client:only="react" />
+</ComponentPreview>
+
+| Appearance | Treatment                                      | When to use                                                |
+| ---------- | ---------------------------------------------- | ---------------------------------------------------------- |
+| `subtle`   | Tinted background with a faint matching border | Default. Inline status without grabbing attention.         |
+| `solid`    | Filled accent background, white text           | High attention. Reserve for blocking errors / strong cues. |
+| `outline`  | Transparent background with a colored border   | Quietest treatment. Useful in dense layouts.               |
+
+```tsx
+<Alert variant="info" appearance="subtle" />
+<Alert variant="info" appearance="solid" />
+<Alert variant="info" appearance="outline" />
+```
+
+## Without an icon
+
+Pass `icon={false}` to drop the icon column, or pass any `ReactNode` to override the default.
+
+<ComponentPreview title="Without icon">
+  <AlertWithoutIcon client:only="react" />
+</ComponentPreview>
+
+```tsx
+<Alert icon={false} variant="warning" title="Read-only">
+  Switch to edit mode.
+</Alert>
+
+<Alert icon={<MyCustomIcon />} variant="info">
+  Custom icon.
+</Alert>
+```
+
+## Dismissible
+
+Provide `onClose` to render a close button in the top-right.
+
+<ComponentPreview title="Dismissible">
+  <AlertDismissible client:only="react" />
+</ComponentPreview>
+
+```tsx
+const [open, setOpen] = useState(true);
+
+{
+  open && (
+    <Alert
+      variant="success"
+      title="Export complete"
+      onClose={() => setOpen(false)}
+    >
+      The scene was exported successfully.
+    </Alert>
+  );
+}
+```
+
+The close button is keyboard-reachable in the default tab order and uses `aria-label="Close alert"`.
+
+## Compact
+
+Title only, or description only — both work. The icon stays unless you opt out.
+
+<ComponentPreview title="Compact">
+  <AlertCompact client:only="react" />
+</ComponentPreview>
+
+```tsx
+<Alert variant="info">Auto-save is on.</Alert>
+```
+
+## With actions
+
+Use `Alert.Actions` to render action buttons below the description.
+
+<ComponentPreview title="With actions">
+  <AlertWithActions client:only="react" />
+</ComponentPreview>
+
+```tsx
+<Alert variant="error" title="Couldn't reach the server">
+  <Alert.Description>The request timed out after 30 seconds.</Alert.Description>
+  <Alert.Actions align="right">
+    <Button variant="filled" onClick={retry}>
+      Retry
+    </Button>
+    <Button onClick={dismiss}>Dismiss</Button>
+  </Alert.Actions>
+</Alert>
+```
+
+The `align` prop controls horizontal placement: `left` (default), `right`, or `space-between`.
+
+## Long content
+
+The body wraps naturally. Stack multiple `Alert.Description` blocks for paragraphs.
+
+<ComponentPreview title="Long content">
+  <AlertLongContent client:only="react" />
+</ComponentPreview>
+
+## Editor example
+
+Pin a read-only warning above an inspector panel.
+
+<ComponentPreview title="Editor example">
+  <AlertReadOnlyFile client:only="react" />
+</ComponentPreview>
+
+## Compound API
+
+`Alert` exposes three compound members. They can be used as `Alert.Title` / `Alert.Description` / `Alert.Actions`, or imported as named exports (`AlertTitle`, etc.) — both refer to the same component.
+
+```tsx
+<Alert variant="info">
+  <Alert.Title>Heads up</Alert.Title>
+  <Alert.Description>This is the body of the alert.</Alert.Description>
+  <Alert.Actions>
+    <Button>Dismiss</Button>
+  </Alert.Actions>
+</Alert>
+```
+
+If both the `title` prop and an `<Alert.Title>` child are supplied, both render — pick one.
+
+## Accessibility
+
+- Role is derived from the variant: `alert` for `error` / `warning` (assertive), `status` for `info` / `success` (polite), `region` with an `aria-label` for `neutral`.
+- The component **doesn't auto-focus**. Inline alerts shouldn't grab focus — that's the job of `Dialog` and `Toast`.
+- The icon is marked `aria-hidden="true"`; meaning is conveyed by the text and the role.
+- The close button (when present) has `aria-label="Close alert"` and follows the default tab order.
+- Color contrast meets WCAG AA across all five variants in both `subtle` and `solid` appearances on the dark theme.
+
+## Props
+
+### Alert
+
+<PropsTable
+  props={[
+    {
+      name: 'variant',
+      type: "'info' | 'success' | 'warning' | 'error' | 'neutral'",
+      default: "'info'",
+      description: 'Semantic intent. Drives color and the default icon.',
+    },
+    {
+      name: 'appearance',
+      type: "'subtle' | 'solid' | 'outline'",
+      default: "'subtle'",
+      description: 'Visual treatment.',
+    },
+    {
+      name: 'icon',
+      type: 'ReactNode | false',
+      default: 'true',
+      description:
+        'Icon at the start. `false` hides the icon; any ReactNode overrides the default.',
+    },
+    {
+      name: 'onClose',
+      type: '() => void',
+      description:
+        'When provided, renders a close button and calls this on click.',
+    },
+    {
+      name: 'title',
+      type: 'ReactNode',
+      description:
+        'Convenience prop equivalent to wrapping with `<Alert.Title>`.',
+    },
+    {
+      name: 'children',
+      type: 'ReactNode',
+      description:
+        'Compound children (Title / Description / Actions) or a plain string treated as the description.',
+    },
+    {
+      name: 'className',
+      type: 'string',
+      description: 'Additional CSS class names.',
+    },
+    { name: 'style', type: 'CSSProperties', description: 'Inline styles.' },
+    {
+      name: 'testId',
+      type: 'string',
+      description: 'Test identifier for automated testing.',
+    },
+    {
+      name: 'ref',
+      type: 'Ref<HTMLDivElement>',
+      description: 'Ref to the alert root element.',
+    },
+  ]}
+/>
+
+### Alert.Title
+
+<PropsTable
+  props={[
+    { name: 'children', type: 'ReactNode', description: 'Title content.' },
+    {
+      name: 'className',
+      type: 'string',
+      description: 'Additional CSS class names.',
+    },
+    { name: 'style', type: 'CSSProperties', description: 'Inline styles.' },
+    {
+      name: 'testId',
+      type: 'string',
+      description: 'Test identifier for automated testing.',
+    },
+    {
+      name: 'ref',
+      type: 'Ref<HTMLDivElement>',
+      description: 'Ref to the title element.',
+    },
+  ]}
+/>
+
+### Alert.Description
+
+<PropsTable
+  props={[
+    {
+      name: 'children',
+      type: 'ReactNode',
+      description: 'Description body content.',
+    },
+    {
+      name: 'className',
+      type: 'string',
+      description: 'Additional CSS class names.',
+    },
+    { name: 'style', type: 'CSSProperties', description: 'Inline styles.' },
+    {
+      name: 'testId',
+      type: 'string',
+      description: 'Test identifier for automated testing.',
+    },
+    {
+      name: 'ref',
+      type: 'Ref<HTMLDivElement>',
+      description: 'Ref to the description element.',
+    },
+  ]}
+/>
+
+### Alert.Actions
+
+<PropsTable
+  props={[
+    {
+      name: 'children',
+      type: 'ReactNode',
+      description: 'Action buttons.',
+    },
+    {
+      name: 'align',
+      type: "'left' | 'right' | 'space-between'",
+      default: "'left'",
+      description: 'Horizontal alignment of the action row.',
+    },
+    {
+      name: 'className',
+      type: 'string',
+      description: 'Additional CSS class names.',
+    },
+    { name: 'style', type: 'CSSProperties', description: 'Inline styles.' },
+    {
+      name: 'testId',
+      type: 'string',
+      description: 'Test identifier for automated testing.',
+    },
+    {
+      name: 'ref',
+      type: 'Ref<HTMLDivElement>',
+      description: 'Ref to the actions row element.',
+    },
+  ]}
+/>

--- a/src/components/feedback/Alert/Alert.css.ts
+++ b/src/components/feedback/Alert/Alert.css.ts
@@ -20,9 +20,9 @@ export const alertOnSolidVar = createVar();
 
 export const alertRecipe = recipe({
   base: {
-    display: 'grid',
-    gridTemplateColumns: 'auto 1fr auto',
-    columnGap: vars.spacing.md,
+    display: 'flex',
+    alignItems: 'flex-start',
+    gap: vars.spacing.md,
     padding: vars.spacing.md,
     borderRadius: vars.borderRadius.md,
     fontFamily: vars.typography.fontFamily.sans,
@@ -82,11 +82,15 @@ export const alertIconSolidStyle = style({
 });
 
 /**
- * Center column — flexible content area for title / description / actions.
+ * Center slot — flexible content area for title / description / actions.
+ *
+ * `flex: 1` claims remaining horizontal space; `min-width: 0` lets long
+ * content wrap instead of overflowing the alert.
  */
 export const alertContentStyle = style({
   display: 'flex',
   flexDirection: 'column',
+  flex: 1,
   minWidth: 0,
 });
 
@@ -124,21 +128,20 @@ export const alertTitleStyle = style({
 });
 
 /**
- * Standalone (no title) description: drop the top spacing it would otherwise
- * inherit from the title's bottom margin.
+ * Description text. Defaults to the secondary token; switches to the
+ * on-solid color when nested inside a solid-appearance alert via the
+ * parent attribute selector. This handles both string children (auto-wrapped
+ * in `AlertDescription`) and the compound `<Alert.Description>` API uniformly.
  */
 export const alertDescriptionStyle = style({
   fontSize: vars.typography.fontSize.md,
   lineHeight: vars.typography.lineHeight.normal,
   color: vars.colors.text.secondary,
-});
-
-/**
- * Solid appearance: secondary text would lose contrast on a saturated
- * background; force the on-solid color.
- */
-export const alertDescriptionSolidStyle = style({
-  color: alertOnSolidVar,
+  selectors: {
+    '[data-appearance="solid"] &': {
+      color: alertOnSolidVar,
+    },
+  },
 });
 
 export const alertActionsRecipe = recipe({

--- a/src/components/feedback/Alert/Alert.css.ts
+++ b/src/components/feedback/Alert/Alert.css.ts
@@ -1,0 +1,161 @@
+import { style, createVar } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+import { vars } from '@/theme/contract.css';
+
+/**
+ * Per-instance variant color, set by the component via `assignInlineVars`
+ * based on the `variant` prop. The recipe styles below reference it so the
+ * appearance axis can stay variant-agnostic.
+ */
+export const alertColorVar = createVar();
+
+/**
+ * Solid-appearance text color.
+ *
+ * Hard-coded white (`#ffffff`) by default; consumers can override via
+ * `--alert-on-solid` if they need something different. White-on-accent gives
+ * the highest contrast across the dark-first palette and matches the spec.
+ */
+export const alertOnSolidVar = createVar();
+
+export const alertRecipe = recipe({
+  base: {
+    display: 'grid',
+    gridTemplateColumns: 'auto 1fr auto',
+    columnGap: vars.spacing.md,
+    padding: vars.spacing.md,
+    borderRadius: vars.borderRadius.md,
+    fontFamily: vars.typography.fontFamily.sans,
+    fontSize: vars.typography.fontSize.md,
+    lineHeight: vars.typography.lineHeight.normal,
+    boxSizing: 'border-box',
+    vars: {
+      [alertOnSolidVar]: '#ffffff',
+    },
+  },
+  variants: {
+    variant: {
+      info: {},
+      success: {},
+      warning: {},
+      error: {},
+      neutral: {},
+    },
+    appearance: {
+      subtle: {
+        background: `color-mix(in srgb, ${alertColorVar} 12%, transparent)`,
+        border: `1px solid color-mix(in srgb, ${alertColorVar} 30%, transparent)`,
+        color: vars.colors.text.primary,
+      },
+      solid: {
+        background: alertColorVar,
+        border: `1px solid ${alertColorVar}`,
+        color: alertOnSolidVar,
+      },
+      outline: {
+        background: 'transparent',
+        border: `1px solid ${alertColorVar}`,
+        color: vars.colors.text.primary,
+      },
+    },
+  },
+  defaultVariants: {
+    variant: 'info',
+    appearance: 'subtle',
+  },
+});
+
+/**
+ * Icon column — 20px square, top-aligned with the title.
+ */
+export const alertIconStyle = style({
+  display: 'flex',
+  alignItems: 'flex-start',
+  justifyContent: 'center',
+  width: '20px',
+  flexShrink: 0,
+  color: alertColorVar,
+});
+
+export const alertIconSolidStyle = style({
+  color: alertOnSolidVar,
+});
+
+/**
+ * Center column — flexible content area for title / description / actions.
+ */
+export const alertContentStyle = style({
+  display: 'flex',
+  flexDirection: 'column',
+  minWidth: 0,
+});
+
+/**
+ * Right column — close button slot, 20px wide, top-aligned.
+ */
+export const alertCloseColumnStyle = style({
+  display: 'flex',
+  alignItems: 'flex-start',
+  justifyContent: 'center',
+  width: '20px',
+  flexShrink: 0,
+});
+
+/**
+ * Override the close-button color in solid appearance — defaults to white,
+ * matching `alertOnSolidVar`.
+ */
+export const alertCloseButtonSolidStyle = style({
+  color: alertOnSolidVar,
+});
+
+/**
+ * Title styling.
+ *
+ * Solid appearance inherits the on-solid color from the root; subtle/outline
+ * use the standard primary text token (already applied by the root recipe).
+ */
+export const alertTitleStyle = style({
+  fontSize: vars.typography.fontSize.md,
+  fontWeight: vars.typography.fontWeight.semibold,
+  lineHeight: vars.typography.lineHeight.tight,
+  color: 'inherit',
+  marginBottom: vars.spacing.xs,
+});
+
+/**
+ * Standalone (no title) description: drop the top spacing it would otherwise
+ * inherit from the title's bottom margin.
+ */
+export const alertDescriptionStyle = style({
+  fontSize: vars.typography.fontSize.md,
+  lineHeight: vars.typography.lineHeight.normal,
+  color: vars.colors.text.secondary,
+});
+
+/**
+ * Solid appearance: secondary text would lose contrast on a saturated
+ * background; force the on-solid color.
+ */
+export const alertDescriptionSolidStyle = style({
+  color: alertOnSolidVar,
+});
+
+export const alertActionsRecipe = recipe({
+  base: {
+    display: 'flex',
+    flexDirection: 'row',
+    gap: vars.spacing.sm,
+    marginTop: vars.spacing.md,
+  },
+  variants: {
+    align: {
+      left: { justifyContent: 'flex-start' },
+      right: { justifyContent: 'flex-end' },
+      'space-between': { justifyContent: 'space-between' },
+    },
+  },
+  defaultVariants: {
+    align: 'left',
+  },
+});

--- a/src/components/feedback/Alert/Alert.stories.tsx
+++ b/src/components/feedback/Alert/Alert.stories.tsx
@@ -1,0 +1,169 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Alert } from './Alert';
+import { Stack } from '@/components/layout/Stack';
+import { Button } from '@/components/primitives/Button';
+import { PropertyPanel } from '@/components/editor/PropertyInspector';
+
+const meta: Meta<typeof Alert> = {
+  title: 'Feedback/Alert',
+  component: Alert,
+  parameters: { layout: 'centered' },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['info', 'success', 'warning', 'error', 'neutral'],
+    },
+    appearance: {
+      control: 'select',
+      options: ['subtle', 'solid', 'outline'],
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Alert>;
+
+export const Default: Story = {
+  args: {
+    variant: 'info',
+    title: 'Heads up',
+    children: 'This is a persistent inline alert.',
+  },
+  render: args => (
+    <div style={{ width: 420 }}>
+      <Alert {...args} />
+    </div>
+  ),
+};
+
+export const Variants: Story = {
+  render: () => (
+    <Stack spacing={3} style={{ width: 420 }}>
+      <Alert variant="info" title="Informational">
+        New revisions are available. Pull the latest scene before editing.
+      </Alert>
+      <Alert variant="success" title="Saved">
+        All asset overrides have been written to disk.
+      </Alert>
+      <Alert variant="warning" title="Read-only mode">
+        This file is locked by another editor; switch modes to make changes.
+      </Alert>
+      <Alert variant="error" title="Connection lost">
+        We can't reach the render farm. Retry once your network comes back.
+      </Alert>
+      <Alert variant="neutral" title="Note">
+        Drag a node from the library to start a new graph.
+      </Alert>
+    </Stack>
+  ),
+};
+
+export const Appearances: Story = {
+  render: () => (
+    <Stack spacing={3} style={{ width: 420 }}>
+      <Alert variant="info" appearance="subtle" title="Subtle (default)">
+        Tinted background, faint border. Use for inline status.
+      </Alert>
+      <Alert variant="info" appearance="solid" title="Solid">
+        Filled accent background. Loud — reserve for primary calls.
+      </Alert>
+      <Alert variant="info" appearance="outline" title="Outline">
+        Bordered, transparent background. Quietest treatment.
+      </Alert>
+    </Stack>
+  ),
+};
+
+export const WithoutIcon: Story = {
+  render: () => (
+    <div style={{ width: 420 }}>
+      <Alert variant="warning" icon={false} title="Read-only">
+        Switch to edit mode to make changes.
+      </Alert>
+    </div>
+  ),
+};
+
+export const Dismissible: Story = {
+  render: function DismissibleStory() {
+    const [open, setOpen] = useState(true);
+    if (!open) {
+      return <Button onClick={() => setOpen(true)}>Restore alert</Button>;
+    }
+    return (
+      <div style={{ width: 420 }}>
+        <Alert
+          variant="success"
+          title="Export complete"
+          onClose={() => setOpen(false)}
+        >
+          The scene has been exported to <code>~/exports/scene.usd</code>.
+        </Alert>
+      </div>
+    );
+  },
+};
+
+export const Compact: Story = {
+  render: () => (
+    <div style={{ width: 420 }}>
+      <Alert variant="info">Auto-save is on.</Alert>
+    </div>
+  ),
+};
+
+export const WithActions: Story = {
+  render: () => (
+    <div style={{ width: 460 }}>
+      <Alert variant="error" title="Couldn't reach the server">
+        <Alert.Description>
+          The request timed out after 30 seconds.
+        </Alert.Description>
+        <Alert.Actions align="right">
+          <Button variant="filled">Retry</Button>
+          <Button>Dismiss</Button>
+        </Alert.Actions>
+      </Alert>
+    </div>
+  ),
+};
+
+export const LongContent: Story = {
+  render: () => (
+    <div style={{ width: 480 }}>
+      <Alert variant="warning" title="Pending migration">
+        <Alert.Description>
+          The shader graph format changed in version 0.9. Existing graphs will
+          continue to load, but new features (procedural noise, world-space
+          gradients) require the new schema.
+        </Alert.Description>
+        <Alert.Description style={{ marginTop: 8 }}>
+          Run <code>npx entangle-ui migrate-graphs</code> from the project root
+          to upgrade in place. The original files are written to{' '}
+          <code>.entangle-backup/</code> first, so you can roll back at any
+          time.
+        </Alert.Description>
+      </Alert>
+    </div>
+  ),
+};
+
+export const EditorExample: Story = {
+  render: () => (
+    <div style={{ width: 320 }}>
+      <Stack spacing={3}>
+        <Alert variant="warning" title="Read-only file" appearance="subtle">
+          <Alert.Description>
+            <code>materials/asphalt.json</code> is checked out by another user.
+          </Alert.Description>
+        </Alert>
+        <PropertyPanel size="sm">
+          <div style={{ padding: 12, opacity: 0.6, fontSize: 12 }}>
+            Inspector is read-only.
+          </div>
+        </PropertyPanel>
+      </Stack>
+    </div>
+  ),
+};

--- a/src/components/feedback/Alert/Alert.test.tsx
+++ b/src/components/feedback/Alert/Alert.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { FormEvent } from 'react';
 import { renderWithTheme } from '@/tests/testUtils';
 import { Alert } from './Alert';
 import { AlertTitle } from './AlertTitle';
@@ -222,6 +223,26 @@ describe('Alert', () => {
         screen.getByRole('button', { name: 'Close alert' })
       );
       expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not submit a surrounding form when clicked', async () => {
+      const onSubmit = vi.fn((e: FormEvent) => {
+        e.preventDefault();
+      });
+      const onClose = vi.fn();
+      renderWithTheme(
+        <form onSubmit={onSubmit}>
+          <Alert testId="alert" onClose={onClose}>
+            x
+          </Alert>
+          <button type="submit">Save</button>
+        </form>
+      );
+      await userEvent.click(
+        screen.getByRole('button', { name: 'Close alert' })
+      );
+      expect(onClose).toHaveBeenCalledTimes(1);
+      expect(onSubmit).not.toHaveBeenCalled();
     });
   });
 

--- a/src/components/feedback/Alert/Alert.test.tsx
+++ b/src/components/feedback/Alert/Alert.test.tsx
@@ -1,0 +1,367 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithTheme } from '@/tests/testUtils';
+import { Alert } from './Alert';
+import { AlertTitle } from './AlertTitle';
+import { AlertDescription } from './AlertDescription';
+import { AlertActions } from './AlertActions';
+
+describe('Alert', () => {
+  describe('Rendering', () => {
+    it('renders with default props', () => {
+      renderWithTheme(<Alert testId="alert">Heads up</Alert>);
+      const el = screen.getByTestId('alert');
+      expect(el).toBeInTheDocument();
+      expect(el).toHaveAttribute('data-variant', 'info');
+      expect(el).toHaveAttribute('data-appearance', 'subtle');
+    });
+
+    it('renders all variants with correct data attribute', () => {
+      const variants = [
+        'info',
+        'success',
+        'warning',
+        'error',
+        'neutral',
+      ] as const;
+      for (const variant of variants) {
+        const { unmount } = renderWithTheme(
+          <Alert testId={`alert-${variant}`} variant={variant}>
+            x
+          </Alert>
+        );
+        expect(screen.getByTestId(`alert-${variant}`)).toHaveAttribute(
+          'data-variant',
+          variant
+        );
+        unmount();
+      }
+    });
+
+    it('renders all appearances with correct data attribute', () => {
+      const appearances = ['subtle', 'solid', 'outline'] as const;
+      for (const appearance of appearances) {
+        const { unmount } = renderWithTheme(
+          <Alert testId={`alert-${appearance}`} appearance={appearance}>
+            x
+          </Alert>
+        );
+        expect(screen.getByTestId(`alert-${appearance}`)).toHaveAttribute(
+          'data-appearance',
+          appearance
+        );
+        unmount();
+      }
+    });
+
+    it('produces a different recipe class per appearance', () => {
+      const { rerender } = renderWithTheme(
+        <Alert testId="alert" appearance="subtle">
+          x
+        </Alert>
+      );
+      const subtleClass = screen.getByTestId('alert').className;
+      rerender(
+        <Alert testId="alert" appearance="solid">
+          x
+        </Alert>
+      );
+      const solidClass = screen.getByTestId('alert').className;
+      rerender(
+        <Alert testId="alert" appearance="outline">
+          x
+        </Alert>
+      );
+      const outlineClass = screen.getByTestId('alert').className;
+      expect(subtleClass).not.toBe(solidClass);
+      expect(subtleClass).not.toBe(outlineClass);
+      expect(solidClass).not.toBe(outlineClass);
+    });
+
+    it('forwards custom className', () => {
+      renderWithTheme(
+        <Alert testId="alert" className="my-alert">
+          x
+        </Alert>
+      );
+      expect(screen.getByTestId('alert').className).toContain('my-alert');
+    });
+
+    it('renders the title prop', () => {
+      renderWithTheme(
+        <Alert testId="alert" title="Heads up">
+          Body
+        </Alert>
+      );
+      expect(screen.getByText('Heads up')).toBeInTheDocument();
+    });
+
+    it('renders compound Alert.Title children', () => {
+      renderWithTheme(
+        <Alert testId="alert">
+          <Alert.Title>Heads up</Alert.Title>
+          <Alert.Description>Some description</Alert.Description>
+        </Alert>
+      );
+      expect(screen.getByText('Heads up')).toBeInTheDocument();
+      expect(screen.getByText('Some description')).toBeInTheDocument();
+    });
+
+    it('renders string children as description (no title)', () => {
+      renderWithTheme(<Alert testId="alert">Just a description</Alert>);
+      expect(screen.getByText('Just a description')).toBeInTheDocument();
+    });
+  });
+
+  describe('Icons', () => {
+    it('renders a default icon for info variant', () => {
+      renderWithTheme(
+        <Alert testId="alert" variant="info">
+          x
+        </Alert>
+      );
+      const icon = screen
+        .getByTestId('alert')
+        .querySelector('[data-alert-icon]');
+      expect(icon).not.toBeNull();
+    });
+
+    it('renders a default icon for success variant', () => {
+      renderWithTheme(
+        <Alert testId="alert" variant="success">
+          x
+        </Alert>
+      );
+      expect(
+        screen.getByTestId('alert').querySelector('[data-alert-icon]')
+      ).not.toBeNull();
+    });
+
+    it('renders a default icon for warning variant', () => {
+      renderWithTheme(
+        <Alert testId="alert" variant="warning">
+          x
+        </Alert>
+      );
+      expect(
+        screen.getByTestId('alert').querySelector('[data-alert-icon]')
+      ).not.toBeNull();
+    });
+
+    it('renders a default icon for error variant', () => {
+      renderWithTheme(
+        <Alert testId="alert" variant="error">
+          x
+        </Alert>
+      );
+      expect(
+        screen.getByTestId('alert').querySelector('[data-alert-icon]')
+      ).not.toBeNull();
+    });
+
+    it('does not render an icon for neutral variant by default', () => {
+      renderWithTheme(
+        <Alert testId="alert" variant="neutral">
+          x
+        </Alert>
+      );
+      expect(
+        screen.getByTestId('alert').querySelector('[data-alert-icon]')
+      ).toBeNull();
+    });
+
+    it('hides the icon when icon={false}', () => {
+      renderWithTheme(
+        <Alert testId="alert" icon={false}>
+          x
+        </Alert>
+      );
+      expect(
+        screen.getByTestId('alert').querySelector('[data-alert-icon]')
+      ).toBeNull();
+    });
+
+    it('uses a custom icon when icon={<CustomIcon/>}', () => {
+      renderWithTheme(
+        <Alert testId="alert" icon={<span data-testid="custom-icon">!</span>}>
+          x
+        </Alert>
+      );
+      expect(screen.getByTestId('custom-icon')).toBeInTheDocument();
+    });
+  });
+
+  describe('Close button', () => {
+    it('does not render the close button when onClose is omitted', () => {
+      renderWithTheme(<Alert testId="alert">x</Alert>);
+      expect(
+        screen.queryByRole('button', { name: 'Close alert' })
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders the close button when onClose is provided', () => {
+      renderWithTheme(
+        <Alert testId="alert" onClose={() => undefined}>
+          x
+        </Alert>
+      );
+      expect(
+        screen.getByRole('button', { name: 'Close alert' })
+      ).toBeInTheDocument();
+    });
+
+    it('calls onClose when close button is clicked', async () => {
+      const onClose = vi.fn();
+      renderWithTheme(
+        <Alert testId="alert" onClose={onClose}>
+          x
+        </Alert>
+      );
+      await userEvent.click(
+        screen.getByRole('button', { name: 'Close alert' })
+      );
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('uses role="alert" for error variant', () => {
+      renderWithTheme(
+        <Alert testId="alert" variant="error">
+          Boom
+        </Alert>
+      );
+      expect(screen.getByTestId('alert')).toHaveAttribute('role', 'alert');
+    });
+
+    it('uses role="alert" for warning variant', () => {
+      renderWithTheme(
+        <Alert testId="alert" variant="warning">
+          Heads up
+        </Alert>
+      );
+      expect(screen.getByTestId('alert')).toHaveAttribute('role', 'alert');
+    });
+
+    it('uses role="status" for info variant', () => {
+      renderWithTheme(
+        <Alert testId="alert" variant="info">
+          FYI
+        </Alert>
+      );
+      expect(screen.getByTestId('alert')).toHaveAttribute('role', 'status');
+    });
+
+    it('uses role="status" for success variant', () => {
+      renderWithTheme(
+        <Alert testId="alert" variant="success">
+          Done
+        </Alert>
+      );
+      expect(screen.getByTestId('alert')).toHaveAttribute('role', 'status');
+    });
+
+    it('uses role="region" with aria-label for neutral variant', () => {
+      renderWithTheme(
+        <Alert testId="alert" variant="neutral">
+          Note
+        </Alert>
+      );
+      const el = screen.getByTestId('alert');
+      expect(el).toHaveAttribute('role', 'region');
+      expect(el).toHaveAttribute('aria-label');
+    });
+
+    it('close button has aria-label="Close alert"', () => {
+      renderWithTheme(
+        <Alert testId="alert" onClose={() => undefined}>
+          x
+        </Alert>
+      );
+      expect(
+        screen.getByRole('button', { name: 'Close alert' })
+      ).toBeInTheDocument();
+    });
+  });
+});
+
+describe('Alert.Title', () => {
+  it('renders content', () => {
+    renderWithTheme(<AlertTitle testId="title">Hello</AlertTitle>);
+    expect(screen.getByTestId('title')).toHaveTextContent('Hello');
+  });
+
+  it('forwards custom className', () => {
+    renderWithTheme(
+      <AlertTitle testId="title" className="t">
+        Hello
+      </AlertTitle>
+    );
+    expect(screen.getByTestId('title').className).toContain('t');
+  });
+
+  it('is also reachable via Alert.Title', () => {
+    expect(Alert.Title).toBe(AlertTitle);
+  });
+});
+
+describe('Alert.Description', () => {
+  it('renders content', () => {
+    renderWithTheme(<AlertDescription testId="desc">Body</AlertDescription>);
+    expect(screen.getByTestId('desc')).toHaveTextContent('Body');
+  });
+
+  it('forwards custom className', () => {
+    renderWithTheme(
+      <AlertDescription testId="desc" className="d">
+        Body
+      </AlertDescription>
+    );
+    expect(screen.getByTestId('desc').className).toContain('d');
+  });
+
+  it('is also reachable via Alert.Description', () => {
+    expect(Alert.Description).toBe(AlertDescription);
+  });
+});
+
+describe('Alert.Actions', () => {
+  it('renders children', () => {
+    renderWithTheme(
+      <AlertActions testId="actions">
+        <button>Retry</button>
+      </AlertActions>
+    );
+    expect(screen.getByTestId('actions')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+  });
+
+  it('produces a different class per align value', () => {
+    const { rerender } = renderWithTheme(
+      <AlertActions testId="actions" align="left">
+        <button>a</button>
+      </AlertActions>
+    );
+    const left = screen.getByTestId('actions').className;
+    rerender(
+      <AlertActions testId="actions" align="right">
+        <button>a</button>
+      </AlertActions>
+    );
+    const right = screen.getByTestId('actions').className;
+    rerender(
+      <AlertActions testId="actions" align="space-between">
+        <button>a</button>
+      </AlertActions>
+    );
+    const between = screen.getByTestId('actions').className;
+    expect(left).not.toBe(right);
+    expect(left).not.toBe(between);
+    expect(right).not.toBe(between);
+  });
+
+  it('is also reachable via Alert.Actions', () => {
+    expect(Alert.Actions).toBe(AlertActions);
+  });
+});

--- a/src/components/feedback/Alert/Alert.tsx
+++ b/src/components/feedback/Alert/Alert.tsx
@@ -1,0 +1,209 @@
+'use client';
+
+import React from 'react';
+import { assignInlineVars } from '@vanilla-extract/dynamic';
+import { cx } from '@/utils/cx';
+import { vars } from '@/theme/contract.css';
+import { IconButton } from '@/components/primitives/IconButton';
+import { CloseIcon } from '@/components/Icons/CloseIcon';
+import { InfoIcon } from '@/components/Icons/InfoIcon';
+import { CheckIcon } from '@/components/Icons/CheckIcon';
+import { WarningIcon } from '@/components/Icons/WarningIcon';
+import { ErrorIcon } from '@/components/Icons/ErrorIcon';
+import type { AlertProps, AlertVariant } from './Alert.types';
+import {
+  alertCloseButtonSolidStyle,
+  alertCloseColumnStyle,
+  alertColorVar,
+  alertContentStyle,
+  alertDescriptionSolidStyle,
+  alertIconSolidStyle,
+  alertIconStyle,
+  alertRecipe,
+} from './Alert.css';
+import { AlertTitle } from './AlertTitle';
+import { AlertDescription } from './AlertDescription';
+import { AlertActions } from './AlertActions';
+
+const VARIANT_COLOR: Record<AlertVariant, string> = {
+  info: vars.colors.accent.primary,
+  success: vars.colors.accent.success,
+  warning: vars.colors.accent.warning,
+  error: vars.colors.accent.error,
+  neutral: vars.colors.text.muted,
+};
+
+const VARIANT_ROLE: Record<AlertVariant, { role: string; ariaLabel?: string }> =
+  {
+    info: { role: 'status' },
+    success: { role: 'status' },
+    warning: { role: 'alert' },
+    error: { role: 'alert' },
+    neutral: { role: 'region', ariaLabel: 'Notice' },
+  };
+
+const VARIANT_DEFAULT_ICON: Record<AlertVariant, React.ReactNode> = {
+  info: <InfoIcon size="md" decorative />,
+  success: <CheckIcon size="md" decorative />,
+  warning: <WarningIcon size="md" decorative />,
+  error: <ErrorIcon size="md" decorative />,
+  neutral: null,
+};
+
+/**
+ * Persistent inline alert / callout.
+ *
+ * Use for non-transient status messages tied to the surrounding UI — read-only
+ * notices, expired credentials, unsaved-changes banners, etc. For transient
+ * confirmations like "File saved", reach for `useToast` instead.
+ *
+ * Compound API: pair with `<Alert.Title>`, `<Alert.Description>`, and
+ * `<Alert.Actions>` for richer layouts. The same components are also
+ * available as standalone named exports (`AlertTitle`, `AlertDescription`,
+ * `AlertActions`).
+ *
+ * Accessibility: roles are derived from the variant — `alert` for
+ * `error`/`warning`, `status` for `info`/`success`, `region` for `neutral`.
+ * The component never auto-focuses; inline alerts shouldn't grab focus.
+ *
+ * @example
+ * ```tsx
+ * <Alert variant="warning" title="Read-only mode">
+ *   Switch to edit mode to make changes.
+ * </Alert>
+ *
+ * <Alert variant="error" onClose={() => setOpen(false)}>
+ *   <Alert.Title>Couldn't reach the server</Alert.Title>
+ *   <Alert.Description>The request timed out.</Alert.Description>
+ *   <Alert.Actions align="right">
+ *     <Button onClick={retry}>Retry</Button>
+ *   </Alert.Actions>
+ * </Alert>
+ * ```
+ */
+const AlertImpl = /*#__PURE__*/ React.memo<AlertProps>(
+  ({
+    variant = 'info',
+    appearance = 'subtle',
+    icon = true,
+    onClose,
+    title,
+    children,
+    className,
+    style,
+    testId,
+    'aria-label': ariaLabelProp,
+    ref,
+    ...rest
+  }) => {
+    const isSolid = appearance === 'solid';
+    const { role, ariaLabel: defaultAriaLabel } = VARIANT_ROLE[variant];
+
+    const resolvedIcon: React.ReactNode =
+      icon === false
+        ? null
+        : icon === true
+          ? VARIANT_DEFAULT_ICON[variant]
+          : icon;
+
+    const inlineVars = assignInlineVars({
+      [alertColorVar]: VARIANT_COLOR[variant],
+    });
+
+    return (
+      <div
+        ref={ref}
+        role={role}
+        aria-label={ariaLabelProp ?? defaultAriaLabel}
+        className={cx(alertRecipe({ variant, appearance }), className)}
+        style={{ ...inlineVars, ...style }}
+        data-testid={testId}
+        data-variant={variant}
+        data-appearance={appearance}
+        {...rest}
+      >
+        {resolvedIcon ? (
+          <div
+            className={cx(alertIconStyle, isSolid && alertIconSolidStyle)}
+            data-alert-icon=""
+            aria-hidden="true"
+          >
+            {resolvedIcon}
+          </div>
+        ) : (
+          <span aria-hidden="true" />
+        )}
+
+        <div className={alertContentStyle}>
+          {title !== undefined && title !== null ? (
+            <AlertTitle>{title}</AlertTitle>
+          ) : null}
+          {typeof children === 'string' ? (
+            <AlertDescription
+              className={isSolid ? alertDescriptionSolidStyle : undefined}
+            >
+              {children}
+            </AlertDescription>
+          ) : isSolid ? (
+            <SolidColorScope>{children}</SolidColorScope>
+          ) : (
+            children
+          )}
+        </div>
+
+        {onClose ? (
+          <div className={alertCloseColumnStyle}>
+            <IconButton
+              aria-label="Close alert"
+              variant="ghost"
+              size="sm"
+              radius="sm"
+              onClick={onClose}
+              className={isSolid ? alertCloseButtonSolidStyle : undefined}
+            >
+              <CloseIcon size="sm" decorative />
+            </IconButton>
+          </div>
+        ) : (
+          <span aria-hidden="true" />
+        )}
+      </div>
+    );
+  }
+);
+
+AlertImpl.displayName = 'Alert';
+
+/**
+ * Wraps non-string children in solid appearance so the description text
+ * inherits the on-solid token. Title color already inherits via `color: inherit`.
+ */
+const SolidColorScope: React.FC<{ children?: React.ReactNode }> = ({
+  children,
+}) => (
+  <div
+    className={alertDescriptionSolidStyle}
+    style={{ display: 'contents' }}
+    data-alert-solid-scope=""
+  >
+    {children}
+  </div>
+);
+
+/**
+ * Public API: `Alert` with attached compound members.
+ *
+ * `React.memo` returns an exotic component that doesn't accept arbitrary
+ * static fields with proper typing — we expose the compound members through
+ * a typed wrapper.
+ */
+type AlertCompound = typeof AlertImpl & {
+  Title: typeof AlertTitle;
+  Description: typeof AlertDescription;
+  Actions: typeof AlertActions;
+};
+
+export const Alert = AlertImpl as AlertCompound;
+Alert.Title = AlertTitle;
+Alert.Description = AlertDescription;
+Alert.Actions = AlertActions;

--- a/src/components/feedback/Alert/Alert.tsx
+++ b/src/components/feedback/Alert/Alert.tsx
@@ -16,7 +16,6 @@ import {
   alertCloseColumnStyle,
   alertColorVar,
   alertContentStyle,
-  alertDescriptionSolidStyle,
   alertIconSolidStyle,
   alertIconStyle,
   alertRecipe,
@@ -130,22 +129,14 @@ const AlertImpl = /*#__PURE__*/ React.memo<AlertProps>(
           >
             {resolvedIcon}
           </div>
-        ) : (
-          <span aria-hidden="true" />
-        )}
+        ) : null}
 
         <div className={alertContentStyle}>
           {title !== undefined && title !== null ? (
             <AlertTitle>{title}</AlertTitle>
           ) : null}
           {typeof children === 'string' ? (
-            <AlertDescription
-              className={isSolid ? alertDescriptionSolidStyle : undefined}
-            >
-              {children}
-            </AlertDescription>
-          ) : isSolid ? (
-            <SolidColorScope>{children}</SolidColorScope>
+            <AlertDescription>{children}</AlertDescription>
           ) : (
             children
           )}
@@ -154,6 +145,7 @@ const AlertImpl = /*#__PURE__*/ React.memo<AlertProps>(
         {onClose ? (
           <div className={alertCloseColumnStyle}>
             <IconButton
+              type="button"
               aria-label="Close alert"
               variant="ghost"
               size="sm"
@@ -164,31 +156,13 @@ const AlertImpl = /*#__PURE__*/ React.memo<AlertProps>(
               <CloseIcon size="sm" decorative />
             </IconButton>
           </div>
-        ) : (
-          <span aria-hidden="true" />
-        )}
+        ) : null}
       </div>
     );
   }
 );
 
 AlertImpl.displayName = 'Alert';
-
-/**
- * Wraps non-string children in solid appearance so the description text
- * inherits the on-solid token. Title color already inherits via `color: inherit`.
- */
-const SolidColorScope: React.FC<{ children?: React.ReactNode }> = ({
-  children,
-}) => (
-  <div
-    className={alertDescriptionSolidStyle}
-    style={{ display: 'contents' }}
-    data-alert-solid-scope=""
-  >
-    {children}
-  </div>
-);
 
 /**
  * Public API: `Alert` with attached compound members.

--- a/src/components/feedback/Alert/Alert.types.ts
+++ b/src/components/feedback/Alert/Alert.types.ts
@@ -1,0 +1,98 @@
+import type React from 'react';
+import type { BaseComponent } from '@/types/common';
+import type { Prettify } from '@/types/utilities';
+
+/**
+ * Semantic intent of an alert.
+ *
+ * - `info`     — neutral information (default)
+ * - `success`  — positive confirmation
+ * - `warning`  — caution / attention required
+ * - `error`    — destructive / blocking issue
+ * - `neutral`  — passive status banner without coloring
+ */
+export type AlertVariant = 'info' | 'success' | 'warning' | 'error' | 'neutral';
+
+/**
+ * Visual treatment of an alert.
+ *
+ * - `subtle`   — tinted background (default; recommended for inline alerts)
+ * - `solid`    — filled accent background; high attention, use sparingly
+ * - `outline`  — bordered, transparent background; low visual weight
+ */
+export type AlertAppearance = 'subtle' | 'solid' | 'outline';
+
+export interface AlertBaseProps extends Omit<
+  BaseComponent<HTMLDivElement>,
+  'title'
+> {
+  /**
+   * Semantic intent. Drives color and the default icon.
+   * @default "info"
+   */
+  variant?: AlertVariant;
+
+  /**
+   * Visual treatment.
+   * @default "subtle"
+   */
+  appearance?: AlertAppearance;
+
+  /**
+   * Show an icon at the start.
+   *
+   * - `true` (default) renders the variant's default icon
+   * - `false` hides the icon column entirely
+   * - any `ReactNode` overrides the default icon
+   *
+   * Default-icon mapping: info → `InfoIcon`, success → `CheckIcon`,
+   * warning → `WarningIcon`, error → `ErrorIcon`, neutral → none.
+   * @default true
+   */
+  icon?: React.ReactNode | false;
+
+  /**
+   * When provided, renders a close button in the top-right corner
+   * and calls this handler when it's clicked.
+   */
+  onClose?: () => void;
+
+  /**
+   * Optional title — convenience prop equivalent to wrapping with `<Alert.Title>`.
+   * If both `title` and `<Alert.Title>` children are used, both render
+   * (don't do this; pick one).
+   */
+  title?: React.ReactNode;
+
+  /**
+   * Children — typically `Alert.Title` / `Alert.Description` / `Alert.Actions`.
+   * Plain string content is also fine (treated as description).
+   */
+  children?: React.ReactNode;
+}
+
+export type AlertProps = Prettify<AlertBaseProps>;
+
+export interface AlertTitleBaseProps extends BaseComponent<HTMLDivElement> {
+  children: React.ReactNode;
+}
+
+export type AlertTitleProps = Prettify<AlertTitleBaseProps>;
+
+export interface AlertDescriptionBaseProps extends BaseComponent<HTMLDivElement> {
+  children: React.ReactNode;
+}
+
+export type AlertDescriptionProps = Prettify<AlertDescriptionBaseProps>;
+
+export interface AlertActionsBaseProps extends BaseComponent<HTMLDivElement> {
+  /**
+   * Horizontal alignment of action buttons.
+   * @default "left"
+   */
+  align?: 'left' | 'right' | 'space-between';
+
+  children: React.ReactNode;
+}
+
+export type AlertActionsProps = Prettify<AlertActionsBaseProps>;

--- a/src/components/feedback/Alert/AlertActions.tsx
+++ b/src/components/feedback/Alert/AlertActions.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import React from 'react';
+import { cx } from '@/utils/cx';
+import type { AlertActionsProps } from './Alert.types';
+import { alertActionsRecipe } from './Alert.css';
+
+/**
+ * Action-button row for an `Alert`. Lays out children with a horizontal gap
+ * and configurable alignment. Renders only when actions are needed — for
+ * dismissible alerts the close button in the top-right is usually enough.
+ *
+ * @example
+ * ```tsx
+ * <Alert variant="error">
+ *   <Alert.Title>Couldn't reach the server</Alert.Title>
+ *   <Alert.Description>The request timed out after 30 seconds.</Alert.Description>
+ *   <Alert.Actions align="right">
+ *     <Button variant="filled" onClick={retry}>Retry</Button>
+ *     <Button onClick={dismiss}>Dismiss</Button>
+ *   </Alert.Actions>
+ * </Alert>
+ * ```
+ */
+export const AlertActions = /*#__PURE__*/ React.memo<AlertActionsProps>(
+  ({ children, align = 'left', className, style, testId, ref, ...rest }) => {
+    return (
+      <div
+        ref={ref}
+        className={cx(alertActionsRecipe({ align }), className)}
+        style={style}
+        data-testid={testId}
+        data-alert-actions=""
+        {...rest}
+      >
+        {children}
+      </div>
+    );
+  }
+);
+
+AlertActions.displayName = 'AlertActions';

--- a/src/components/feedback/Alert/AlertDescription.tsx
+++ b/src/components/feedback/Alert/AlertDescription.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import React from 'react';
+import { cx } from '@/utils/cx';
+import type { AlertDescriptionProps } from './Alert.types';
+import { alertDescriptionStyle } from './Alert.css';
+
+/**
+ * Body text slot for an `Alert`. Most one-line alerts can pass a string as
+ * children to `<Alert>` directly; reach for this when you need to compose
+ * multiple paragraphs or inline elements.
+ *
+ * @example
+ * ```tsx
+ * <Alert variant="info">
+ *   <Alert.Title>Heads up</Alert.Title>
+ *   <Alert.Description>
+ *     This editor is read-only. Open the file in edit mode to make changes.
+ *   </Alert.Description>
+ * </Alert>
+ * ```
+ */
+export const AlertDescription = /*#__PURE__*/ React.memo<AlertDescriptionProps>(
+  ({ children, className, style, testId, ref, ...rest }) => {
+    return (
+      <div
+        ref={ref}
+        className={cx(alertDescriptionStyle, className)}
+        style={style}
+        data-testid={testId}
+        data-alert-description=""
+        {...rest}
+      >
+        {children}
+      </div>
+    );
+  }
+);
+
+AlertDescription.displayName = 'AlertDescription';

--- a/src/components/feedback/Alert/AlertTitle.tsx
+++ b/src/components/feedback/Alert/AlertTitle.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import React from 'react';
+import { cx } from '@/utils/cx';
+import type { AlertTitleProps } from './Alert.types';
+import { alertTitleStyle } from './Alert.css';
+
+/**
+ * Title slot for an `Alert`. Renders a single line of emphasized text above
+ * the description.
+ *
+ * Equivalent to passing `title` directly on `<Alert>`. Use this form when you
+ * want richer content (links, inline elements) inside the title.
+ *
+ * @example
+ * ```tsx
+ * <Alert variant="warning">
+ *   <Alert.Title>Read-only mode</Alert.Title>
+ *   <Alert.Description>Switch to edit to change this file.</Alert.Description>
+ * </Alert>
+ * ```
+ */
+export const AlertTitle = /*#__PURE__*/ React.memo<AlertTitleProps>(
+  ({ children, className, style, testId, ref, ...rest }) => {
+    return (
+      <div
+        ref={ref}
+        className={cx(alertTitleStyle, className)}
+        style={style}
+        data-testid={testId}
+        data-alert-title=""
+        {...rest}
+      >
+        {children}
+      </div>
+    );
+  }
+);
+
+AlertTitle.displayName = 'AlertTitle';

--- a/src/components/feedback/Alert/index.ts
+++ b/src/components/feedback/Alert/index.ts
@@ -1,0 +1,12 @@
+export { Alert } from './Alert';
+export { AlertTitle } from './AlertTitle';
+export { AlertDescription } from './AlertDescription';
+export { AlertActions } from './AlertActions';
+export type {
+  AlertProps,
+  AlertTitleProps,
+  AlertDescriptionProps,
+  AlertActionsProps,
+  AlertVariant,
+  AlertAppearance,
+} from './Alert.types';

--- a/src/components/feedback/index.ts
+++ b/src/components/feedback/index.ts
@@ -1,3 +1,13 @@
+export { Alert, AlertTitle, AlertDescription, AlertActions } from './Alert';
+export type {
+  AlertProps,
+  AlertTitleProps,
+  AlertDescriptionProps,
+  AlertActionsProps,
+  AlertVariant,
+  AlertAppearance,
+} from './Alert';
+
 export {
   Dialog,
   DialogHeader,

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,6 +93,10 @@ export {
 } from '@/components/navigation';
 export { FormHelperText, FormLabel, InputWrapper } from '@/components/form';
 export {
+  Alert,
+  AlertActions,
+  AlertDescription,
+  AlertTitle,
   Dialog,
   DialogBody,
   DialogClose,
@@ -307,6 +311,12 @@ export type {
   InputWrapperProps,
 } from '@/components/form';
 export type {
+  AlertActionsProps,
+  AlertAppearance,
+  AlertDescriptionProps,
+  AlertProps,
+  AlertTitleProps,
+  AlertVariant,
   DialogBodyProps,
   DialogFooterProps,
   DialogHeaderProps,


### PR DESCRIPTION
Five semantic variants (info, success, warning, error, neutral) drive color and the default icon, across three visual treatments (subtle, solid, outline). Compound API: Alert.Title / Alert.Description / Alert.Actions, also exported as standalone AlertTitle / AlertDescription / AlertActions. ARIA roles are derived from the variant. Provide onClose to render a dismiss button.

Includes Storybook stories, Astro Starlight docs page, and a changeset.