### PR TITLE
feat(visually-hidden): add VisuallyHidden a11y primitive

### DIFF
--- a/.changeset/visually-hidden-component.md
+++ b/.changeset/visually-hidden-component.md
@@ -1,0 +1,9 @@
+---
+'entangle-ui': minor
+---
+
+Add `VisuallyHidden` primitive for hiding content visually while keeping
+it accessible to screen readers. Implements the canonical SR-only style
+and supports a `focusable` mode for skip-to-content links (revealed via
+`:focus-within`). Renders as `<span>` by default with `as` overrides for
+`div`, `label`, and `p`.

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -83,6 +83,10 @@ export default defineConfig({
                 { label: 'Text', slug: 'components/primitives/text' },
                 { label: 'TextArea', slug: 'components/primitives/text-area' },
                 { label: 'Tooltip', slug: 'components/primitives/tooltip' },
+                {
+                  label: 'VisuallyHidden',
+                  slug: 'components/primitives/visually-hidden',
+                },
               ],
             },
             {

--- a/docs-site/src/components/demos/primitives/VisuallyHiddenDemo.tsx
+++ b/docs-site/src/components/demos/primitives/VisuallyHiddenDemo.tsx
@@ -1,0 +1,128 @@
+import DemoWrapper from '../DemoWrapper';
+import { IconButton, Text, VisuallyHidden } from '@/components/primitives';
+import { Stack } from '@/components/layout';
+import { SearchIcon } from '@/components/Icons/SearchIcon';
+import { SettingsIcon } from '@/components/Icons/SettingsIcon';
+import { TrashIcon } from '@/components/Icons/TrashIcon';
+
+export default function VisuallyHiddenDemo() {
+  return (
+    <DemoWrapper>
+      <Stack gap={4} style={{ maxWidth: 480 }}>
+        <Text>
+          The next words are visually hidden but present in the DOM —{' '}
+          <VisuallyHidden>
+            invisible to sighted users, audible to screen readers
+          </VisuallyHidden>
+          . Inspect the DOM to verify they exist.
+        </Text>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <IconButton aria-label="Search">
+            <SearchIcon />
+          </IconButton>
+          <IconButton aria-label="Settings">
+            <SettingsIcon />
+          </IconButton>
+          <IconButton aria-label="Delete">
+            <TrashIcon />
+          </IconButton>
+        </div>
+      </Stack>
+    </DemoWrapper>
+  );
+}
+
+export function VisuallyHiddenBasic() {
+  return (
+    <DemoWrapper>
+      <Text>
+        This sentence has{' '}
+        <VisuallyHidden>extra context only screen readers hear</VisuallyHidden>{' '}
+        invisible content embedded in it. Open devtools to see it.
+      </Text>
+    </DemoWrapper>
+  );
+}
+
+export function VisuallyHiddenWithSibling() {
+  return (
+    <DemoWrapper>
+      <label
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 4,
+          maxWidth: 320,
+        }}
+      >
+        <span style={{ fontSize: 12 }}>Email</span>
+        <VisuallyHidden>
+          We will only use your email to send password reset links.
+        </VisuallyHidden>
+        <input
+          type="email"
+          placeholder="you@example.com"
+          style={{
+            border: '1px solid var(--etui-color-border-default)',
+            background: 'transparent',
+            color: 'inherit',
+            padding: '4px 8px',
+            borderRadius: 4,
+          }}
+        />
+      </label>
+    </DemoWrapper>
+  );
+}
+
+export function VisuallyHiddenFocusable() {
+  return (
+    <DemoWrapper>
+      <div style={{ position: 'relative', minHeight: 100, padding: 16 }}>
+        <VisuallyHidden focusable>
+          <a href="#main-content">Skip to main content</a>
+        </VisuallyHidden>
+        <Text>
+          Click into this preview, then press{' '}
+          <span style={{ fontFamily: 'var(--etui-font-mono)' }}>Tab</span> — the
+          skip link will appear.
+        </Text>
+        <div id="main-content" style={{ marginTop: 24 }}>
+          <Text size="sm" color="muted">
+            Main content begins here.
+          </Text>
+        </div>
+      </div>
+    </DemoWrapper>
+  );
+}
+
+export function VisuallyHiddenInIconButton() {
+  return (
+    <DemoWrapper>
+      <Stack direction="row" gap={3}>
+        <button
+          type="button"
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 4,
+            border: '1px solid var(--etui-color-border-default)',
+            background: 'transparent',
+            color: 'inherit',
+            padding: '4px 8px',
+            borderRadius: 4,
+            cursor: 'pointer',
+          }}
+        >
+          <SearchIcon />
+          <VisuallyHidden>Search the catalog</VisuallyHidden>
+        </button>
+        <Text size="sm" color="muted">
+          Sighted users see the icon; screen readers announce "Search the
+          catalog".
+        </Text>
+      </Stack>
+    </DemoWrapper>
+  );
+}

--- a/docs-site/src/content/docs/components/primitives/visually-hidden.mdx
+++ b/docs-site/src/content/docs/components/primitives/visually-hidden.mdx
@@ -1,0 +1,157 @@
+---
+title: VisuallyHidden
+description: Hide content visually while keeping it announced by screen readers.
+---
+
+import PropsTable from '../../../../components/PropsTable.astro';
+import ComponentPreview from '../../../../components/ComponentPreview.astro';
+import VisuallyHiddenDemo, {
+  VisuallyHiddenBasic,
+  VisuallyHiddenWithSibling,
+  VisuallyHiddenFocusable,
+  VisuallyHiddenInIconButton,
+} from '../../../../components/demos/primitives/VisuallyHiddenDemo';
+
+Hides its children visually while keeping them in the accessibility tree. This is the canonical `sr-only` / `visually-hidden` pattern used by Tailwind, Bootstrap, and Radix — same CSS, just packaged as a primitive so the rule lives in one place.
+
+Reach for it to label icon-only buttons, surface extra context next to inputs, or build a skip-to-content link. Don't use it to hide content from sighted users for layout reasons — that's `display: none`. This component keeps content audible on purpose.
+
+<ComponentPreview title="Live Preview">
+  <VisuallyHiddenDemo client:only="react" />
+</ComponentPreview>
+
+## Import
+
+```tsx
+import { VisuallyHidden } from 'entangle-ui';
+```
+
+## Usage
+
+```tsx
+<VisuallyHidden>Search the catalog</VisuallyHidden>
+```
+
+## Basic Hidden Content
+
+Children render into the DOM but are clipped to a single transparent pixel. Inspect the element to confirm the text is still there.
+
+<ComponentPreview title="Basic">
+  <VisuallyHiddenBasic client:only="react" />
+</ComponentPreview>
+
+```tsx
+<Text>
+  This sentence has{' '}
+  <VisuallyHidden>extra context only screen readers hear</VisuallyHidden>{' '}
+  invisible content embedded in it.
+</Text>
+```
+
+## With a Visible Sibling
+
+Pair a visible label with a hidden description for a fuller screen-reader experience without cluttering the layout.
+
+<ComponentPreview title="With visible sibling">
+  <VisuallyHiddenWithSibling client:only="react" />
+</ComponentPreview>
+
+```tsx
+<label>
+  <span>Email</span>
+  <VisuallyHidden>
+    We will only use your email to send password reset links.
+  </VisuallyHidden>
+  <input type="email" />
+</label>
+```
+
+## Skip-to-Content Link
+
+Set `focusable` to make the wrapper appear when it (or a descendant) gains focus. This is the standard skip-link pattern — wrap an anchor inside and let `:focus-within` reveal it.
+
+<ComponentPreview title="Focusable (skip-to-content)">
+  <VisuallyHiddenFocusable client:only="react" />
+</ComponentPreview>
+
+```tsx
+<VisuallyHidden focusable>
+  <a href="#main-content">Skip to main content</a>
+</VisuallyHidden>
+```
+
+## Hiding a Label for an Icon-Only Button
+
+Pair a visible icon with a hidden label so assistive tech can announce the action.
+
+<ComponentPreview title="Icon-only button">
+  <VisuallyHiddenInIconButton client:only="react" />
+</ComponentPreview>
+
+```tsx
+<button>
+  <SearchIcon />
+  <VisuallyHidden>Search the catalog</VisuallyHidden>
+</button>
+```
+
+For most cases, prefer `aria-label="Search"` on the button itself — that's terser. Use `VisuallyHidden` when you need rich children (e.g. interpolated values, formatted markup) that `aria-label` cannot express.
+
+## Common Pitfalls
+
+- **Don't use it to hide things from everyone.** `VisuallyHidden` keeps content audible. Use `display: none` or `hidden` if the content should not exist for any user.
+- **Don't put interactive content inside it without `focusable`.** A button hidden with the static styles still receives focus but stays clipped — sighted keyboard users cannot tell where they are.
+- **Don't add `aria-hidden="true"`.** That removes the content from the accessibility tree, defeating the purpose.
+
+## Props
+
+<PropsTable
+  props={[
+    {
+      name: 'children',
+      type: 'ReactNode',
+      required: true,
+      description: 'Content rendered inside the hidden region.',
+    },
+    {
+      name: 'as',
+      type: "'span' | 'div' | 'label' | 'p'",
+      default: "'span'",
+      description:
+        'Element to render. Use `div` for block content or `label`/`p` when the semantics fit.',
+    },
+    {
+      name: 'focusable',
+      type: 'boolean',
+      default: 'false',
+      description:
+        'When true, becomes visible when the element (or a descendant) is focused. Used for skip links.',
+    },
+    {
+      name: 'className',
+      type: 'string',
+      description: 'Additional CSS class names.',
+    },
+    {
+      name: 'style',
+      type: 'CSSProperties',
+      description: 'Inline styles applied to the rendered element.',
+    },
+    {
+      name: 'testId',
+      type: 'string',
+      description: 'Test identifier for automated testing.',
+    },
+    {
+      name: 'ref',
+      type: 'Ref<HTMLSpanElement>',
+      description: 'Ref to the rendered element.',
+    },
+  ]}
+/>
+
+## Accessibility
+
+- Children remain in the DOM and the accessibility tree — screen readers, browser find-in-page, and translation tools all still see them
+- Implements the canonical SR-only style (`position: absolute`, `clip: rect(0,0,0,0)`, `width/height: 1px`) so the element occupies no visual space but is not removed from layout flow
+- `focusable` reveals the element under `:focus` and `:focus-within`, which is exactly what skip links need

--- a/src/components/primitives/VisuallyHidden/VisuallyHidden.css.ts
+++ b/src/components/primitives/VisuallyHidden/VisuallyHidden.css.ts
@@ -1,0 +1,36 @@
+import { style } from '@vanilla-extract/css';
+import { vars } from '@/theme/contract.css';
+
+const hiddenBase = {
+  position: 'absolute',
+  width: '1px',
+  height: '1px',
+  padding: 0,
+  margin: '-1px',
+  overflow: 'hidden',
+  clip: 'rect(0, 0, 0, 0)',
+  whiteSpace: 'nowrap',
+  border: 0,
+} as const;
+
+export const visuallyHiddenStyle = style(hiddenBase);
+
+export const visuallyHiddenFocusableStyle = style({
+  ...hiddenBase,
+  selectors: {
+    '&:focus, &:focus-within, &:active': {
+      position: 'static',
+      width: 'auto',
+      height: 'auto',
+      padding: vars.spacing.sm,
+      margin: 0,
+      overflow: 'visible',
+      clip: 'auto',
+      whiteSpace: 'normal',
+      background: vars.colors.background.elevated,
+      color: vars.colors.text.primary,
+      border: `1px solid ${vars.colors.border.focus}`,
+      borderRadius: vars.borderRadius.sm,
+    },
+  },
+});

--- a/src/components/primitives/VisuallyHidden/VisuallyHidden.stories.tsx
+++ b/src/components/primitives/VisuallyHidden/VisuallyHidden.stories.tsx
@@ -1,0 +1,115 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { VisuallyHidden } from './VisuallyHidden';
+import { Button } from '../Button';
+import { IconButton } from '../IconButton';
+import { SearchIcon } from '@/components/Icons/SearchIcon';
+import { Stack } from '@/components/layout';
+
+const meta: Meta<typeof VisuallyHidden> = {
+  title: 'Primitives/VisuallyHidden',
+  component: VisuallyHidden,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Hides content visually while keeping it accessible to screen readers. Use for SR-only labels, additional context next to icons, and skip-to-content links (with `focusable`).',
+      },
+    },
+  },
+  argTypes: {
+    as: { control: 'select', options: ['span', 'div', 'label', 'p'] },
+    focusable: { control: 'boolean' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof VisuallyHidden>;
+
+export const Default: Story = {
+  render: () => (
+    <p style={{ maxWidth: 480 }}>
+      The next words are visually hidden but present in the DOM —{' '}
+      <VisuallyHidden>
+        invisible to sighted users, audible to screen readers
+      </VisuallyHidden>
+      . Open devtools to verify they exist.
+    </p>
+  ),
+};
+
+export const WithVisibleSibling: Story = {
+  name: 'With visible sibling',
+  render: () => (
+    <Stack direction="column" spacing={2}>
+      <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+        <span>Email</span>
+        <VisuallyHidden>
+          We will only use your email to send password reset links.
+        </VisuallyHidden>
+        <input
+          type="email"
+          style={{
+            border: '1px solid #444',
+            background: 'transparent',
+            color: 'inherit',
+            padding: '4px 8px',
+            borderRadius: 4,
+          }}
+        />
+      </label>
+    </Stack>
+  ),
+};
+
+export const Focusable: Story = {
+  name: 'Focusable (skip-to-content)',
+  render: () => (
+    <div style={{ position: 'relative', minHeight: 120, padding: 16 }}>
+      <VisuallyHidden focusable>
+        <a href="#main-content">Skip to main content</a>
+      </VisuallyHidden>
+      <p style={{ margin: 0, opacity: 0.7 }}>
+        Press <kbd>Tab</kbd> to reveal the skip link.
+      </p>
+      <div id="main-content" style={{ marginTop: 24 }}>
+        Main content begins here.
+      </div>
+    </div>
+  ),
+};
+
+export const InCustomCheckbox: Story = {
+  name: 'Hiding a native input',
+  render: () => (
+    <label style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
+      <span
+        style={{
+          width: 16,
+          height: 16,
+          border: '1px solid #555',
+          borderRadius: 2,
+          display: 'inline-block',
+        }}
+      />
+      <VisuallyHidden>
+        <input type="checkbox" />
+      </VisuallyHidden>
+      <span>Custom checkbox</span>
+    </label>
+  ),
+};
+
+export const InIconButton: Story = {
+  name: 'Label for icon-only button',
+  render: () => (
+    <Stack direction="row" spacing={3}>
+      <IconButton aria-label="Search">
+        <SearchIcon />
+      </IconButton>
+      <Button icon={<SearchIcon />}>
+        <VisuallyHidden>Search the catalog</VisuallyHidden>
+      </Button>
+    </Stack>
+  ),
+};

--- a/src/components/primitives/VisuallyHidden/VisuallyHidden.test.tsx
+++ b/src/components/primitives/VisuallyHidden/VisuallyHidden.test.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { renderWithTheme } from '@/tests/testUtils';
+import { VisuallyHidden } from './VisuallyHidden';
+
+describe('VisuallyHidden', () => {
+  describe('Rendering', () => {
+    it('renders as a <span> by default', () => {
+      renderWithTheme(<VisuallyHidden testId="vh">Hidden text</VisuallyHidden>);
+      const el = screen.getByTestId('vh');
+      expect(el.tagName).toBe('SPAN');
+    });
+
+    it('renders as the element specified by `as`', () => {
+      renderWithTheme(
+        <VisuallyHidden as="div" testId="vh">
+          Block content
+        </VisuallyHidden>
+      );
+      expect(screen.getByTestId('vh').tagName).toBe('DIV');
+    });
+
+    it('renders children into the DOM', () => {
+      renderWithTheme(<VisuallyHidden>Hidden text</VisuallyHidden>);
+      expect(screen.getByText('Hidden text')).toBeInTheDocument();
+    });
+
+    it('forwards extra props to the rendered element', () => {
+      renderWithTheme(
+        <VisuallyHidden id="custom-id" testId="vh">
+          x
+        </VisuallyHidden>
+      );
+      expect(screen.getByTestId('vh')).toHaveAttribute('id', 'custom-id');
+    });
+
+    it('merges custom className', () => {
+      renderWithTheme(
+        <VisuallyHidden className="custom" testId="vh">
+          x
+        </VisuallyHidden>
+      );
+      expect(screen.getByTestId('vh')).toHaveClass('custom');
+    });
+  });
+
+  describe('Hidden styling', () => {
+    it('applies the canonical SR-only styles', () => {
+      renderWithTheme(<VisuallyHidden testId="vh">Hidden</VisuallyHidden>);
+      const styles = window.getComputedStyle(screen.getByTestId('vh'));
+      expect(styles.position).toBe('absolute');
+      expect(styles.width).toBe('1px');
+      expect(styles.height).toBe('1px');
+      expect(styles.overflow).toBe('hidden');
+      expect(styles.whiteSpace).toBe('nowrap');
+    });
+
+    it('does not use display:none — content stays accessible', () => {
+      renderWithTheme(
+        <VisuallyHidden testId="vh">Important context</VisuallyHidden>
+      );
+      const el = screen.getByTestId('vh');
+      const styles = window.getComputedStyle(el);
+      expect(styles.display).not.toBe('none');
+      expect(el.textContent).toBe('Important context');
+    });
+  });
+
+  describe('Focusable variant', () => {
+    it('accepts the focusable prop without error', () => {
+      renderWithTheme(
+        <VisuallyHidden focusable testId="vh" tabIndex={0}>
+          Skip to content
+        </VisuallyHidden>
+      );
+      expect(screen.getByTestId('vh')).toBeInTheDocument();
+    });
+
+    it('still hides content by default when not focused', () => {
+      renderWithTheme(
+        <VisuallyHidden focusable testId="vh" tabIndex={0}>
+          Skip to content
+        </VisuallyHidden>
+      );
+      const styles = window.getComputedStyle(screen.getByTestId('vh'));
+      expect(styles.position).toBe('absolute');
+      expect(styles.width).toBe('1px');
+    });
+
+    it('preserves children when focusable', () => {
+      renderWithTheme(
+        <VisuallyHidden focusable tabIndex={0}>
+          Skip to content
+        </VisuallyHidden>
+      );
+      expect(screen.getByText('Skip to content')).toBeInTheDocument();
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('renders children into the accessibility tree (textContent present)', () => {
+      renderWithTheme(
+        <VisuallyHidden testId="vh">Screen-reader text</VisuallyHidden>
+      );
+      expect(screen.getByTestId('vh').textContent).toBe('Screen-reader text');
+    });
+
+    it('forwards ref to the rendered element', () => {
+      const ref = React.createRef<HTMLSpanElement>();
+      renderWithTheme(<VisuallyHidden ref={ref}>x</VisuallyHidden>);
+      expect(ref.current?.tagName).toBe('SPAN');
+    });
+
+    it('applies aria-* attributes via spread', () => {
+      renderWithTheme(
+        <VisuallyHidden testId="vh" aria-live="polite">
+          Status update
+        </VisuallyHidden>
+      );
+      expect(screen.getByTestId('vh')).toHaveAttribute('aria-live', 'polite');
+    });
+  });
+});

--- a/src/components/primitives/VisuallyHidden/VisuallyHidden.tsx
+++ b/src/components/primitives/VisuallyHidden/VisuallyHidden.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import React from 'react';
+import { cx } from '@/utils/cx';
+import type { VisuallyHiddenProps } from './VisuallyHidden.types';
+import {
+  visuallyHiddenStyle,
+  visuallyHiddenFocusableStyle,
+} from './VisuallyHidden.css';
+
+/**
+ * Hides content visually while keeping it accessible to screen readers.
+ *
+ * Implements the canonical `sr-only` / `visually-hidden` pattern. Use it for
+ * screen-reader-only labels, additional context next to icons, and
+ * skip-to-content links (with `focusable`).
+ *
+ * Don't use this to hide content from sighted users for layout reasons —
+ * that's `display: none`. This component keeps content in the accessibility
+ * tree on purpose.
+ *
+ * @example
+ * ```tsx
+ * // SR-only label next to an icon-only button
+ * <button>
+ *   <SearchIcon />
+ *   <VisuallyHidden>Search</VisuallyHidden>
+ * </button>
+ *
+ * // Skip link revealed on focus
+ * <VisuallyHidden as="a" href="#main" focusable>
+ *   Skip to content
+ * </VisuallyHidden>
+ * ```
+ */
+export const VisuallyHidden = /*#__PURE__*/ React.memo<VisuallyHiddenProps>(
+  ({
+    as: Component = 'span',
+    focusable = false,
+    children,
+    className,
+    style,
+    testId,
+    ref,
+    ...rest
+  }) => {
+    return (
+      <Component
+        ref={ref as React.Ref<never>}
+        className={cx(
+          focusable ? visuallyHiddenFocusableStyle : visuallyHiddenStyle,
+          className
+        )}
+        style={style}
+        data-testid={testId}
+        {...rest}
+      >
+        {children}
+      </Component>
+    );
+  }
+);
+
+VisuallyHidden.displayName = 'VisuallyHidden';

--- a/src/components/primitives/VisuallyHidden/VisuallyHidden.types.ts
+++ b/src/components/primitives/VisuallyHidden/VisuallyHidden.types.ts
@@ -1,0 +1,31 @@
+import type React from 'react';
+import type { BaseComponent } from '@/types/common';
+import type { Prettify } from '@/types/utilities';
+
+/**
+ * HTML element types that VisuallyHidden can render as.
+ *
+ * Most cases use `span` (default). Use `div` when wrapping block content,
+ * `label` for form labels, `p` for prose.
+ */
+export type VisuallyHiddenElement = 'span' | 'div' | 'label' | 'p';
+
+export interface VisuallyHiddenBaseProps extends BaseComponent<HTMLSpanElement> {
+  /**
+   * HTML element to render as.
+   * @default "span"
+   */
+  as?: VisuallyHiddenElement;
+
+  /**
+   * When true, the element becomes visible when it (or any descendant)
+   * receives focus. Used for skip-to-content links.
+   * @default false
+   */
+  focusable?: boolean;
+
+  /** Content rendered inside the hidden region. */
+  children: React.ReactNode;
+}
+
+export type VisuallyHiddenProps = Prettify<VisuallyHiddenBaseProps>;

--- a/src/components/primitives/VisuallyHidden/index.ts
+++ b/src/components/primitives/VisuallyHidden/index.ts
@@ -1,0 +1,5 @@
+export { VisuallyHidden } from './VisuallyHidden';
+export type {
+  VisuallyHiddenElement,
+  VisuallyHiddenProps,
+} from './VisuallyHidden.types';

--- a/src/components/primitives/index.ts
+++ b/src/components/primitives/index.ts
@@ -19,6 +19,7 @@ export { Switch } from './Switch';
 export { Text } from './Text';
 export { TextArea } from './TextArea';
 export { Tooltip } from './Tooltip';
+export { VisuallyHidden } from './VisuallyHidden';
 
 export type {
   AvatarColor,
@@ -88,6 +89,10 @@ export type {
   TooltipPlacement,
   TooltipProps,
 } from './Tooltip';
+export type {
+  VisuallyHiddenElement,
+  VisuallyHiddenProps,
+} from './VisuallyHidden';
 
 // Canvas primitives
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ export {
   Text,
   TextArea,
   Tooltip,
+  VisuallyHidden,
 } from '@/components/primitives';
 export {
   ColorPicker,
@@ -256,6 +257,8 @@ export type {
   TooltipCollisionStrategy,
   TooltipPlacement,
   TooltipProps,
+  VisuallyHiddenElement,
+  VisuallyHiddenProps,
 } from '@/components/primitives';
 export type {
   ColorFormat,


### PR DESCRIPTION
Hides content visually while keeping it in the accessibility tree. Ships the canonical SR-only style and a focusable variant that reveals on :focus-within for skip-to-content links. Includes Storybook stories and an Astro Starlight docs page.