### PR TITLE
feat(hooks): add useTheme for runtime theme reads

### DIFF
--- a/.changeset/use-theme-hook.md
+++ b/.changeset/use-theme-hook.md
@@ -1,0 +1,11 @@
+---
+'entangle-ui': minor
+---
+
+Add `useTheme` hook for runtime theme reads. Returns the resolved CSS
+variable snapshot from `:root`, the detected variant (`'dark'` / `'light'` /
+`'custom'`), and `getToken(path)` / `getVar(path)` helpers for paths like
+`'colors.accent.primary'`. Use it for canvas drawing, third-party libraries
+that take colours as plain strings, and conditional logic — keep using
+Vanilla Extract `vars.*` for ordinary styling. SSR-safe: returns dark-theme
+defaults when no DOM is available.

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -238,6 +238,7 @@ export default defineConfig({
               label: 'useResizeObserver',
               slug: 'hooks/use-resize-observer',
             },
+            { label: 'useTheme', slug: 'hooks/use-theme' },
           ],
         },
         {

--- a/docs-site/src/components/demos/hooks/UseThemeDemo.tsx
+++ b/docs-site/src/components/demos/hooks/UseThemeDemo.tsx
@@ -1,0 +1,171 @@
+import { useEffect, useRef } from 'react';
+import DemoWrapper from '../DemoWrapper';
+import { useTheme } from '@/hooks/useTheme';
+import { Stack } from '@/components/layout/Stack';
+import { Flex } from '@/components/layout/Flex';
+import { Text } from '@/components/primitives/Text';
+import { Code } from '@/components/primitives/Code';
+
+const SAMPLE_PATHS = [
+  'colors.accent.primary',
+  'colors.text.primary',
+  'spacing.md',
+  'borderRadius.md',
+  'shell.menuBar.height',
+];
+
+function ThemedCanvas({ size = 96 }: { size?: number }) {
+  const ref = useRef<HTMLCanvasElement>(null);
+  const { values } = useTheme();
+
+  useEffect(() => {
+    const canvas = ref.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = size * dpr;
+    canvas.height = size * dpr;
+    canvas.style.width = `${size}px`;
+    canvas.style.height = `${size}px`;
+    ctx.scale(dpr, dpr);
+
+    ctx.clearRect(0, 0, size, size);
+
+    ctx.fillStyle = values.colors.background.elevated;
+    ctx.fillRect(0, 0, size, size);
+
+    ctx.beginPath();
+    ctx.arc(size / 2, size / 2, size / 2 - 12, 0, Math.PI * 2);
+    ctx.fillStyle = values.colors.accent.primary;
+    ctx.fill();
+
+    ctx.strokeStyle = values.colors.border.default;
+    ctx.lineWidth = 1;
+    ctx.strokeRect(0.5, 0.5, size - 1, size - 1);
+  }, [size, values]);
+
+  return <canvas ref={ref} />;
+}
+
+export default function UseThemeDemo() {
+  const { variant, values, getVar } = useTheme();
+
+  return (
+    <DemoWrapper>
+      <Stack spacing={3}>
+        <Flex gap={3} align="center">
+          <ThemedCanvas size={96} />
+          <Stack spacing={1}>
+            <Text size="sm" color="secondary">
+              variant
+            </Text>
+            <Text size="md">{variant}</Text>
+            <Text size="sm" color="secondary">
+              accent
+            </Text>
+            <Text size="md">{values.colors.accent.primary}</Text>
+          </Stack>
+        </Flex>
+        <div
+          style={{
+            padding: 12,
+            borderRadius: 4,
+            background: getVar('colors.surface.default'),
+            border: `1px solid ${getVar('colors.border.default')}`,
+            color: getVar('colors.text.primary'),
+          }}
+        >
+          <Text size="sm">
+            Surface, border, and text colour all driven by `getVar`.
+          </Text>
+        </div>
+      </Stack>
+    </DemoWrapper>
+  );
+}
+
+export function UseThemeCanvasDrawing() {
+  return (
+    <DemoWrapper>
+      <Flex gap={3} align="center">
+        <ThemedCanvas size={120} />
+        <Text size="sm" color="secondary">
+          Canvas re-paints whenever <Code>useTheme</Code> resolves new values on
+          mount, using the live <Code>colors.accent.primary</Code> token.
+        </Text>
+      </Flex>
+    </DemoWrapper>
+  );
+}
+
+export function UseThemeConditionalLogic() {
+  const { variant } = useTheme();
+
+  return (
+    <DemoWrapper>
+      <Stack spacing={2}>
+        <Text size="sm" color="secondary">
+          Detected variant: <Code>{variant}</Code>
+        </Text>
+        {variant === 'dark' && (
+          <Text size="md">Dark mode — high-contrast assets loaded.</Text>
+        )}
+        {variant === 'light' && (
+          <Text size="md">Light mode — soft assets loaded.</Text>
+        )}
+        {variant === 'custom' && (
+          <Text size="md">Custom theme — fall back to default assets.</Text>
+        )}
+      </Stack>
+    </DemoWrapper>
+  );
+}
+
+export function UseThemeGetToken() {
+  const { getToken } = useTheme();
+
+  return (
+    <DemoWrapper>
+      <Stack spacing={2}>
+        {SAMPLE_PATHS.map(path => (
+          <Flex key={path} gap={2} align="center" justify="space-between">
+            <Code>{path}</Code>
+            <Text size="sm" color="secondary">
+              {getToken(path) || '(unresolved)'}
+            </Text>
+          </Flex>
+        ))}
+      </Stack>
+    </DemoWrapper>
+  );
+}
+
+export function UseThemeGetVar() {
+  const { getVar } = useTheme();
+
+  return (
+    <DemoWrapper>
+      <Stack spacing={2}>
+        <div
+          style={{
+            padding: '8px 12px',
+            borderRadius: 4,
+            background: getVar('colors.surface.default'),
+            border: `1px solid ${getVar('colors.border.default')}`,
+            color: getVar('colors.accent.primary'),
+            fontWeight: 500,
+          }}
+        >
+          Inline styles via getVar('colors.accent.primary')
+        </div>
+        <Text size="sm" color="secondary">
+          The string is just <Code>var(--etui-...)</Code>, so the browser
+          re-resolves the colour automatically when the surrounding theme class
+          changes.
+        </Text>
+      </Stack>
+    </DemoWrapper>
+  );
+}

--- a/docs-site/src/content/docs/hooks/index.mdx
+++ b/docs-site/src/content/docs/hooks/index.mdx
@@ -16,6 +16,7 @@ The library exports a set of hooks used internally by components and available f
 - [`useKeyboard`](/hooks/use-keyboard) — read the live keyboard state via context
 - [`useMergedRef`](/hooks/use-merged-ref) — merge multiple refs into a single callback ref
 - [`useResizeObserver`](/hooks/use-resize-observer) — observe element size changes with SSR-safe cleanup
+- [`useTheme`](/hooks/use-theme) — read the current theme at runtime — values, variant, and `getToken` / `getVar` helpers
 
 ## Importing
 
@@ -31,6 +32,7 @@ import {
   useHotkey,
   useMergedRef,
   useResizeObserver,
+  useTheme,
 } from 'entangle-ui';
 ```
 

--- a/docs-site/src/content/docs/hooks/use-theme.mdx
+++ b/docs-site/src/content/docs/hooks/use-theme.mdx
@@ -1,0 +1,173 @@
+---
+title: useTheme
+description: Read the current theme — resolved CSS variable values, the active variant, and helpers for canvas drawing or third-party libraries.
+---
+
+import PropsTable from '../../../components/PropsTable.astro';
+import ComponentPreview from '../../../components/ComponentPreview.astro';
+import UseThemeDemo, {
+  UseThemeCanvasDrawing,
+  UseThemeConditionalLogic,
+  UseThemeGetToken,
+  UseThemeGetVar,
+} from '../../../components/demos/hooks/UseThemeDemo';
+
+`useTheme` returns a runtime snapshot of the active theme — the resolved CSS variable values, the detected variant, and helpers for reading individual tokens by path. Reach for it when a feature genuinely cannot use compile-time Vanilla Extract tokens: canvas drawing, third-party libraries that take colours as plain strings, or branching logic that depends on whether the user is in dark or light mode.
+
+For ordinary styling, keep using `vars.*` from `@/theme` — it's zero-runtime and tree-shakeable. `useTheme` exists for the cases where Vanilla Extract isn't an option.
+
+<ComponentPreview title="Live preview">
+  <UseThemeDemo client:only="react" />
+</ComponentPreview>
+
+## Import
+
+```ts
+import { useTheme } from 'entangle-ui';
+```
+
+## Signature
+
+```ts
+function useTheme(): UseThemeReturn;
+
+type ThemeVariant = 'dark' | 'light' | 'custom';
+
+interface UseThemeReturn {
+  variant: ThemeVariant;
+  values: ThemeValues;
+  getToken: (path: string) => string;
+  getVar: (path: string) => string;
+}
+```
+
+## Usage
+
+```tsx
+function AccentSwatch() {
+  const { values } = useTheme();
+  return (
+    <div
+      style={{
+        width: 24,
+        height: 24,
+        background: values.colors.accent.primary,
+      }}
+    />
+  );
+}
+```
+
+## Common patterns
+
+### Canvas drawing with theme-aware colours
+
+Vanilla Extract can't reach into a `<canvas>` — the values from `useTheme` can. Pull the resolved CSS-var values out of `values` and use them directly in your draw loop.
+
+<ComponentPreview title="Canvas drawing">
+  <UseThemeCanvasDrawing client:only="react" />
+</ComponentPreview>
+
+```tsx
+const ref = useRef<HTMLCanvasElement>(null);
+const { values } = useTheme();
+
+useEffect(() => {
+  const ctx = ref.current?.getContext('2d');
+  if (!ctx) return;
+  ctx.fillStyle = values.colors.accent.primary;
+  ctx.fillRect(0, 0, 100, 100);
+}, [values]);
+```
+
+### Conditional logic by variant
+
+When you need to branch on the active theme — preloading dark- or light-tuned image assets, picking a Mapbox basemap style, choosing a Three.js material — read `variant` directly.
+
+<ComponentPreview title="Conditional logic">
+  <UseThemeConditionalLogic client:only="react" />
+</ComponentPreview>
+
+```tsx
+const { variant } = useTheme();
+
+if (variant === 'light') {
+  loadLightAssets();
+} else {
+  loadDarkAssets();
+}
+```
+
+### `getToken` — resolve a single token by path
+
+`getToken` walks the theme contract, reads the underlying CSS custom property, and returns the resolved value as a plain string. Repeated calls for the same path are cached.
+
+<ComponentPreview title="getToken">
+  <UseThemeGetToken client:only="react" />
+</ComponentPreview>
+
+```tsx
+const { getToken } = useTheme();
+
+const accent = getToken('colors.accent.primary'); // → '#007acc'
+const padding = getToken('spacing.md'); // → '8px'
+const menuBar = getToken('shell.menuBar.height'); // → '28px'
+```
+
+### `getVar` — `var()` references for inline styles
+
+`getVar` returns the `var(--etui-...)` reference string. Unlike `getToken`, the result is SSR-safe (it doesn't read the DOM) and the browser re-resolves the colour automatically if the surrounding theme class changes.
+
+<ComponentPreview title="getVar">
+  <UseThemeGetVar client:only="react" />
+</ComponentPreview>
+
+```tsx
+const { getVar } = useTheme();
+
+<div
+  style={{
+    color: getVar('colors.text.primary'),
+    background: getVar('colors.surface.default'),
+  }}
+/>;
+```
+
+## Caveats
+
+- **Root-only scope.** Both `variant` and `values` come from `document.documentElement` — the global root theme. A light-themed subtree wrapped in `VanillaThemeProvider` (e.g. one light dialog inside a dark app) is **not** reflected: `useTheme` called inside that subtree still reports the root variant and root values. For elements inside such a subtree, style with Vanilla Extract `vars.*` so the browser resolves them per scope.
+- **One-shot read on mount.** v0.8 reads the CSS variables once via `useLayoutEffect` and does not subscribe to subsequent class changes. Toggling the root theme at runtime is not reflected — remount the consuming subtree to pick up the new theme. A `MutationObserver`-based subscription may be added in a later release if consumer demand emerges.
+- **SSR fallback is the dark theme.** Without a DOM, `values` mirrors `darkThemeValues`, `getToken` returns the dark-theme defaults, and `getVar` produces the correct `var(--etui-...)` string (which is itself SSR-safe).
+- **Variant detection is root-only.** `'light'` is reported only when the `lightThemeClass` produced by `createLightTheme()` is applied to `document.documentElement` — the same element the hook reads values from, so the two never disagree. `'custom'` is reserved for future explicit detection; themes generated via `createCustomTheme` currently report as `'dark'`.
+- **Prefer `vars.*` for normal styling.** `useTheme` exists for runtime reads that genuinely need plain strings (canvas, third-party libs, branching logic). Anywhere a Vanilla Extract token works, that's the right tool — it has no runtime cost and no re-render.
+
+## API
+
+<PropsTable
+  props={[
+    {
+      name: 'variant',
+      type: "'dark' | 'light' | 'custom'",
+      description:
+        "Detected theme variant. `'dark'` is the default; `'light'` is reported when the light-theme class is present in the document.",
+    },
+    {
+      name: 'values',
+      type: 'ThemeValues',
+      description:
+        'Resolved theme values — the same shape as `darkThemeValues`/`lightThemeValues`, with each leaf replaced by the current CSS variable value.',
+    },
+    {
+      name: 'getToken',
+      type: '(path: string) => string',
+      description:
+        "Resolve a single token by path (e.g. `'colors.accent.primary'`). Returns an empty string for unknown paths. Cached per path for the life of the hook instance.",
+    },
+    {
+      name: 'getVar',
+      type: '(path: string) => string',
+      description:
+        'Get the `var(--etui-...)` reference for a token. SSR-safe and ideal for inline styles that should follow theme changes automatically.',
+    },
+  ]}
+/>

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -35,3 +35,10 @@ export type { UseClickOutsideOptions } from './useClickOutside';
 
 export { useHotkey } from './useHotkey';
 export type { UseHotkeyOptions } from './useHotkey';
+
+export { useTheme } from './useTheme';
+export type {
+  ResolvedThemeValues,
+  ThemeVariant,
+  UseThemeReturn,
+} from './useTheme';

--- a/src/hooks/useTheme/index.ts
+++ b/src/hooks/useTheme/index.ts
@@ -1,0 +1,6 @@
+export { useTheme } from './useTheme';
+export type {
+  ResolvedThemeValues,
+  ThemeVariant,
+  UseThemeReturn,
+} from './useTheme.types';

--- a/src/hooks/useTheme/useTheme.test.ts
+++ b/src/hooks/useTheme/useTheme.test.ts
@@ -1,0 +1,215 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { lightThemeClass } from '@/theme';
+import { useTheme } from './useTheme';
+
+const TEST_TOKENS: Record<string, string> = {
+  '--etui-color-accent-primary': '#007acc',
+  '--etui-color-text-primary': '#ffffff',
+  '--etui-spacing-md': '8px',
+  '--etui-shell-menubar-height': '28px',
+  '--etui-radius-md': '4px',
+  '--etui-color-surface-white-overlay': 'rgba(255, 255, 255, 0.1)',
+};
+
+function applyTokens(target: HTMLElement, tokens: Record<string, string>) {
+  for (const [name, value] of Object.entries(tokens)) {
+    target.style.setProperty(name, value);
+  }
+}
+
+function clearTokens(target: HTMLElement, tokens: Record<string, string>) {
+  for (const name of Object.keys(tokens)) {
+    target.style.removeProperty(name);
+  }
+}
+
+describe('useTheme', () => {
+  beforeEach(() => {
+    applyTokens(document.documentElement, TEST_TOKENS);
+  });
+
+  afterEach(() => {
+    clearTokens(document.documentElement, TEST_TOKENS);
+    document.documentElement.classList.remove(lightThemeClass);
+    document.body.classList.remove(lightThemeClass);
+  });
+
+  describe('snapshot resolution', () => {
+    it('reads top-level token values from CSS variables', () => {
+      const { result } = renderHook(() => useTheme());
+      expect(result.current.values.colors.accent.primary).toBe('#007acc');
+      expect(result.current.values.colors.text.primary).toBe('#ffffff');
+    });
+
+    it('reads nested shell tokens under their kebab-cased CSS var names', () => {
+      const { result } = renderHook(() => useTheme());
+      expect(result.current.values.shell.menuBar.height).toBe('28px');
+    });
+
+    it('falls back to dark-theme defaults when a CSS var is unset', () => {
+      document.documentElement.style.removeProperty(
+        '--etui-color-accent-primary'
+      );
+      const { result } = renderHook(() => useTheme());
+      // Falls back to the darkThemeValues entry (#007acc happens to match),
+      // so override with a different missing token to verify behaviour.
+      document.documentElement.style.removeProperty('--etui-spacing-xxxl');
+      expect(result.current.values.spacing.xxxl).toBe('32px');
+    });
+  });
+
+  describe('variant detection (root-only)', () => {
+    it('defaults to dark when no light-theme class is present', () => {
+      const { result } = renderHook(() => useTheme());
+      expect(result.current.variant).toBe('dark');
+    });
+
+    it('detects light variant when documentElement has lightThemeClass', () => {
+      document.documentElement.classList.add(lightThemeClass);
+      const { result } = renderHook(() => useTheme());
+      expect(result.current.variant).toBe('light');
+    });
+
+    it('stays dark when lightThemeClass is only on body', () => {
+      // CSS custom properties on <body> don't propagate up to
+      // documentElement, so the variant must not flip — otherwise the
+      // reported variant would disagree with the resolved values.
+      document.body.classList.add(lightThemeClass);
+      const { result } = renderHook(() => useTheme());
+      expect(result.current.variant).toBe('dark');
+    });
+
+    it('stays dark when lightThemeClass is only on a descendant subtree', () => {
+      // A scoped light dialog inside a dark app must not flip the
+      // root-level reading — variant comes from documentElement only.
+      const subtree = document.createElement('div');
+      subtree.classList.add(lightThemeClass);
+      document.body.appendChild(subtree);
+      const { result } = renderHook(() => useTheme());
+      expect(result.current.variant).toBe('dark');
+      subtree.remove();
+    });
+  });
+
+  describe('scope coherence (root-only reads)', () => {
+    it('reports root values even when called inside a light subtree', () => {
+      // Apply tokens to documentElement (the dark root).
+      // Add a light subtree that overrides accent locally — useTheme
+      // must continue to report the root values, not the subtree's.
+      const subtree = document.createElement('div');
+      subtree.classList.add(lightThemeClass);
+      subtree.style.setProperty('--etui-color-accent-primary', '#0066cc');
+      document.body.appendChild(subtree);
+
+      const { result } = renderHook(() => useTheme());
+
+      expect(result.current.variant).toBe('dark');
+      expect(result.current.values.colors.accent.primary).toBe('#007acc');
+      expect(result.current.getToken('colors.accent.primary')).toBe('#007acc');
+
+      subtree.remove();
+    });
+  });
+
+  describe('getToken', () => {
+    it('resolves a leaf path to the current CSS-var value', () => {
+      const { result } = renderHook(() => useTheme());
+      expect(result.current.getToken('colors.accent.primary')).toBe('#007acc');
+      expect(result.current.getToken('spacing.md')).toBe('8px');
+    });
+
+    it('resolves the kebab-cased shell paths correctly', () => {
+      const { result } = renderHook(() => useTheme());
+      expect(result.current.getToken('shell.menuBar.height')).toBe('28px');
+    });
+
+    it('handles camelCase → kebab-case token names like whiteOverlay', () => {
+      const { result } = renderHook(() => useTheme());
+      expect(result.current.getToken('colors.surface.whiteOverlay')).toBe(
+        'rgba(255, 255, 255, 0.1)'
+      );
+    });
+
+    it('returns empty string for an unknown path', () => {
+      const { result } = renderHook(() => useTheme());
+      expect(result.current.getToken('does.not.exist')).toBe('');
+    });
+
+    it('caches per-path so getComputedStyle is not called repeatedly', () => {
+      const spy = vi.spyOn(window, 'getComputedStyle');
+      const { result } = renderHook(() => useTheme());
+      const beforeCalls = spy.mock.calls.length;
+
+      result.current.getToken('colors.accent.primary');
+      result.current.getToken('colors.accent.primary');
+      result.current.getToken('colors.accent.primary');
+
+      expect(spy.mock.calls.length - beforeCalls).toBe(1);
+      spy.mockRestore();
+    });
+
+    it('falls back to dark-theme defaults when the CSS var is empty', () => {
+      document.documentElement.style.removeProperty(
+        '--etui-color-text-primary'
+      );
+      const { result } = renderHook(() => useTheme());
+      expect(result.current.getToken('colors.text.primary')).toBe('#ffffff');
+    });
+  });
+
+  describe('getVar', () => {
+    it('returns the var() reference for a known token', () => {
+      const { result } = renderHook(() => useTheme());
+      expect(result.current.getVar('colors.accent.primary')).toBe(
+        'var(--etui-color-accent-primary)'
+      );
+    });
+
+    it('returns the kebab-cased reference for nested shell paths', () => {
+      const { result } = renderHook(() => useTheme());
+      expect(result.current.getVar('shell.menuBar.height')).toBe(
+        'var(--etui-shell-menubar-height)'
+      );
+    });
+
+    it('returns empty string for unknown paths', () => {
+      const { result } = renderHook(() => useTheme());
+      expect(result.current.getVar('not.a.real.path')).toBe('');
+    });
+  });
+
+  describe('callback stability', () => {
+    it('getToken and getVar identities are stable across renders', () => {
+      const { result, rerender } = renderHook(() => useTheme());
+      const first = {
+        getToken: result.current.getToken,
+        getVar: result.current.getVar,
+      };
+      rerender();
+      expect(result.current.getToken).toBe(first.getToken);
+      expect(result.current.getVar).toBe(first.getVar);
+    });
+  });
+
+  describe('SSR fallback paths', () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('getToken returns the dark-theme default when document is undefined', () => {
+      const { result } = renderHook(() => useTheme());
+      // Mount happened against a real document; now mimic SSR for fresh
+      // (uncached) lookups by removing the global.
+      vi.stubGlobal('document', undefined);
+      expect(result.current.getToken('borderRadius.md')).toBe('4px');
+      expect(result.current.getToken('typography.fontSize.md')).toBe('12px');
+    });
+
+    it('getToken returns empty string for an unknown path during SSR', () => {
+      const { result } = renderHook(() => useTheme());
+      vi.stubGlobal('document', undefined);
+      expect(result.current.getToken('nope.not.real')).toBe('');
+    });
+  });
+});

--- a/src/hooks/useTheme/useTheme.ts
+++ b/src/hooks/useTheme/useTheme.ts
@@ -1,0 +1,218 @@
+'use client';
+
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { darkThemeValues, lightThemeClass, vars } from '@/theme';
+import type {
+  ResolvedThemeValues,
+  ThemeVariant,
+  UseThemeReturn,
+} from './useTheme.types';
+
+const VAR_REF_PATTERN = /^var\((--[^,)]+)/;
+
+/**
+ * Walk a dot-path on the theme contract and return the underlying CSS
+ * custom property name (without the leading `var(`/trailing `)`).
+ *
+ * The contract emits hand-tuned, non-derivable names — `colors.accent.primary`
+ * resolves to `--etui-color-accent-primary`, not `--etui-colors-accent-primary`.
+ * Walking the existing `vars` object (whose leaves are already
+ * `var(--etui-...)` references) is the only correct way to get the var name.
+ *
+ * Returns `''` for paths that don't resolve to a leaf reference.
+ */
+function pathToCssVar(path: string): string {
+  const segments = path.split('.');
+  let node: unknown = vars;
+  for (const segment of segments) {
+    if (
+      node !== null &&
+      typeof node === 'object' &&
+      segment in (node as Record<string, unknown>)
+    ) {
+      node = (node as Record<string, unknown>)[segment];
+    } else {
+      return '';
+    }
+  }
+  if (typeof node !== 'string') return '';
+  const match = VAR_REF_PATTERN.exec(node);
+  return match?.[1] ?? '';
+}
+
+function pathToVarRef(path: string): string {
+  const cssVar = pathToCssVar(path);
+  return cssVar ? `var(${cssVar})` : '';
+}
+
+/**
+ * Walk the dark-theme template alongside the contract, replacing each
+ * leaf with the resolved CSS variable value read from `root`. Falls back
+ * to the template value when a property is empty (e.g. before stylesheets
+ * have applied during testing).
+ */
+function resolveValues<T>(template: T, root: Element, contract: unknown): T {
+  if (typeof template === 'string') {
+    if (typeof contract === 'string') {
+      const match = VAR_REF_PATTERN.exec(contract);
+      const cssVar = match?.[1];
+      if (cssVar) {
+        const value = getComputedStyle(root).getPropertyValue(cssVar).trim();
+        return (value || template) as T;
+      }
+    }
+    return template;
+  }
+  if (template !== null && typeof template === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(template as Record<string, unknown>)) {
+      const childTemplate = (template as Record<string, unknown>)[key];
+      const childContract = (contract as Record<string, unknown> | undefined)?.[
+        key
+      ];
+      out[key] = resolveValues(childTemplate, root, childContract);
+    }
+    return out as T;
+  }
+  return template;
+}
+
+function readTemplateValue(template: unknown, path: string): string {
+  const segments = path.split('.');
+  let node: unknown = template;
+  for (const segment of segments) {
+    if (
+      node !== null &&
+      typeof node === 'object' &&
+      segment in (node as Record<string, unknown>)
+    ) {
+      node = (node as Record<string, unknown>)[segment];
+    } else {
+      return '';
+    }
+  }
+  return typeof node === 'string' ? node : '';
+}
+
+/**
+ * Root-only detection: the variant is determined by whether the
+ * light-theme class is applied to `document.documentElement` — the same
+ * element from which `values` are resolved. Anything more permissive
+ * (descendant scan, `<body>` check) would let the variant disagree with
+ * the resolved values for a dark app that contains a single light
+ * subtree.
+ */
+function detectVariant(): ThemeVariant {
+  if (typeof document === 'undefined') return 'dark';
+  if (!lightThemeClass) return 'dark';
+  if (document.documentElement.classList.contains(lightThemeClass)) {
+    return 'light';
+  }
+  return 'dark';
+}
+
+interface ThemeSnapshot {
+  variant: ThemeVariant;
+  values: ResolvedThemeValues;
+}
+
+const FALLBACK_SNAPSHOT: ThemeSnapshot = {
+  variant: 'dark',
+  values: darkThemeValues as ResolvedThemeValues,
+};
+
+/**
+ * Read the current theme at runtime.
+ *
+ * Returns the resolved CSS variable snapshot from `:root`, the detected
+ * theme variant, and helpers for reading individual tokens by path.
+ * Components should prefer compile-time tokens via Vanilla Extract
+ * (`vars.*` from `@/theme`) — reach for `useTheme` only when a runtime
+ * read is genuinely required (canvas drawing, third-party libraries that
+ * take colors as plain strings).
+ *
+ * **Scope:** the hook always reads from `:root` — both the variant and
+ * the resolved values come from `document.documentElement`. A light- or
+ * custom-themed subtree wrapped in `VanillaThemeProvider` will **not** be
+ * reflected here; for that, components inside the subtree should style
+ * via Vanilla Extract `vars.*` (which the browser resolves correctly per
+ * scope) rather than runtime reads.
+ *
+ * **SSR:** returns the dark-theme defaults as a fallback. The hook
+ * re-evaluates against the live DOM on mount via `useLayoutEffect`, so
+ * the second render contains the real values before the browser paints.
+ *
+ * **Reactivity:** v0.8 reads once on mount. Toggling the root theme at
+ * runtime is not reflected — remount the consuming subtree to pick up
+ * the new theme. A `MutationObserver`-based subscription may be added
+ * in a later release if consumer demand emerges.
+ *
+ * @example
+ * ```tsx
+ * const { values, variant, getVar, getToken } = useTheme();
+ *
+ * // Canvas drawing with theme-aware colors
+ * ctx.strokeStyle = values.colors.accent.primary;
+ *
+ * // Conditional logic
+ * if (variant === 'dark') loadDarkAssets();
+ *
+ * // Inline styles that follow theme changes automatically
+ * <div style={{ color: getVar('colors.text.primary') }} />
+ *
+ * // One-off token resolution
+ * const accent = getToken('colors.accent.primary');
+ * ```
+ */
+export function useTheme(): UseThemeReturn {
+  const tokenCacheRef = useRef<Map<string, string>>(new Map());
+  const [snapshot, setSnapshot] = useState<ThemeSnapshot>(FALLBACK_SNAPSHOT);
+
+  useLayoutEffect(() => {
+    if (typeof document === 'undefined') return;
+    const root = document.documentElement;
+    const next: ThemeSnapshot = {
+      variant: detectVariant(),
+      values: resolveValues(darkThemeValues, root, vars) as ResolvedThemeValues,
+    };
+    tokenCacheRef.current.clear();
+    setSnapshot(next);
+  }, []);
+
+  const getToken = useCallback((path: string): string => {
+    const cache = tokenCacheRef.current;
+    const cached = cache.get(path);
+    if (cached !== undefined) return cached;
+
+    if (typeof document === 'undefined') {
+      const fallback = readTemplateValue(darkThemeValues, path);
+      cache.set(path, fallback);
+      return fallback;
+    }
+
+    const cssVar = pathToCssVar(path);
+    if (!cssVar) {
+      cache.set(path, '');
+      return '';
+    }
+
+    const value = getComputedStyle(document.documentElement)
+      .getPropertyValue(cssVar)
+      .trim();
+    const resolved = value || readTemplateValue(darkThemeValues, path);
+    cache.set(path, resolved);
+    return resolved;
+  }, []);
+
+  const getVar = useCallback((path: string): string => pathToVarRef(path), []);
+
+  return useMemo(
+    () => ({
+      variant: snapshot.variant,
+      values: snapshot.values,
+      getToken,
+      getVar,
+    }),
+    [snapshot, getToken, getVar]
+  );
+}

--- a/src/hooks/useTheme/useTheme.types.ts
+++ b/src/hooks/useTheme/useTheme.types.ts
@@ -1,0 +1,63 @@
+import type { ThemeValues } from '@/theme';
+
+/**
+ * Same shape as `ThemeValues` but with each leaf widened to `string`.
+ *
+ * `darkThemeValues` is declared `as const`, which makes its leaf types
+ * literal (e.g. `'#007acc'`). At runtime the hook reads arbitrary CSS
+ * custom-property strings from the DOM — those values are not constrained
+ * to the dark-theme literals, so the return type widens to plain strings
+ * to stay sound for light, custom, or computed values.
+ */
+export type ResolvedThemeValues = WidenLeaves<ThemeValues>;
+
+type WidenLeaves<T> = T extends string
+  ? string
+  : T extends number
+    ? number
+    : { -readonly [K in keyof T]: WidenLeaves<T[K]> };
+
+/**
+ * Detected theme variant.
+ *
+ * Detection is **root-only**: the hook reports `'light'` only when the
+ * `lightThemeClass` produced by `createLightTheme()` is applied to
+ * `document.documentElement` — the same element the hook reads CSS
+ * variable values from. A light-themed subtree wrapped in
+ * `VanillaThemeProvider` does **not** flip this variant, because the
+ * resolved values would still come from the root.
+ *
+ * - `'dark'` — the default; no `lightThemeClass` on `:root`.
+ * - `'light'` — `lightThemeClass` is on `:root`.
+ * - `'custom'` — reserved. v0.8 does not auto-detect themes produced by
+ *   `createCustomTheme(selector, overrides)`; the union member exists so
+ *   future releases can add detection without a breaking type change.
+ */
+export type ThemeVariant = 'dark' | 'light' | 'custom';
+
+export interface UseThemeReturn {
+  /** Current root-theme variant. See `ThemeVariant` for detection rules. */
+  variant: ThemeVariant;
+  /** Resolved theme values — CSS variable values read from `:root`. */
+  values: ResolvedThemeValues;
+  /**
+   * Resolve a single token to its current CSS-var value, e.g. `'#007acc'`.
+   *
+   * Falls back to the dark-theme default when the underlying CSS variable
+   * is unset or when no DOM is available (SSR). Returns an empty string
+   * only for paths that don't resolve to a leaf in the theme contract.
+   * Repeated calls for the same path are cached for the life of the hook
+   * instance.
+   */
+  getToken: (path: string) => string;
+  /**
+   * Get the `var(--etui-...)` reference for a token, e.g.
+   * `'var(--etui-color-accent-primary)'`. Useful for inline styles that
+   * must follow theme changes automatically.
+   *
+   * SSR-safe — the returned string is constructed from the contract and
+   * works identically in browser and server rendering. Returns an empty
+   * string only for paths that don't resolve to a leaf in the contract.
+   */
+  getVar: (path: string) => string;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export {
 } from '@/theme';
 export type {
   ThemeVars,
+  ThemeValues,
   DarkThemeValues,
   LightThemeValues,
   VanillaThemeProviderProps,
@@ -497,6 +498,7 @@ export {
   useKeyboard,
   useMergedRef,
   useResizeObserver,
+  useTheme,
   isKeyPressed,
   isModifierKey,
 } from '@/hooks';
@@ -506,6 +508,8 @@ export type {
   KeyboardState,
   KeyCode,
   ModifierKeys,
+  ResolvedThemeValues,
+  ThemeVariant,
   UseClickOutsideOptions,
   UseClipboardOptions,
   UseClipboardReturn,
@@ -515,6 +519,7 @@ export type {
   UseFocusTrapOptions,
   UseHotkeyOptions,
   UseResizeObserverOptions,
+  UseThemeReturn,
 } from '@/hooks';
 
 // Utilities


### PR DESCRIPTION
Exposes a runtime snapshot of the active theme — resolved CSS variable values, the detected variant, and getToken / getVar helpers for paths like 'colors.accent.primary'. Targets canvas drawing, third-party libs that take colours as plain strings, and conditional logic that depends on the variant; ordinary styling should keep using vars.* from @/theme.

Detection is root-only: variant and values both come from document.documentElement so the two cannot disagree. ResolvedThemeValues widens leaves to plain strings (darkThemeValues is `as const`, which would otherwise type leaves as literals like '#007acc' — unsound for runtime CSS reads). SSR returns dark-theme defaults; reactivity is a single mount-time read in v0.8.

Includes tests, Astro Starlight docs (page + sidebar entry + hooks overview update), demo file with all named exports, and changeset.