### PR TITLE
fix: KeyboardContext crash, missing icon exports, stale styles.css docs

### DIFF
--- a/.changeset/keyboard-context-and-icons.md
+++ b/.changeset/keyboard-context-and-icons.md
@@ -1,0 +1,10 @@
+---
+'entangle-ui': patch
+---
+
+Fix runtime crash in `Slider`, `NumberInput`, and `VectorInput` when used without a manual `KeyboardContextProvider` wrapper, and expose the icon set and provider from the package barrel.
+
+- `useKeyboardContext` now returns a neutral keyboard state (no pressed keys, all modifiers `false`) when no provider is mounted, instead of throwing. This unblocks every minimal setup that renders a `Slider` / `NumberInput` directly under `ThemeProvider`.
+- `ThemeProvider` now auto-mounts `KeyboardContextProvider` so apps get full Shift/Ctrl modifier awareness in `Slider` / `NumberInput` for free.
+- `KeyboardContextProvider`, `useKeyboardContext`, `useEffectsOnKeyboard`, and the `KeyboardContextProviderProps` type are now exported from the package entry for explicit use in apps that don't render a `ThemeProvider`.
+- The 63 built-in icon components (`SaveIcon`, `PlayIcon`, `AddIcon`, …) are now re-exported from the package entry, matching the documentation.

--- a/.claude/skills/entangle-ui/SKILL.md
+++ b/.claude/skills/entangle-ui/SKILL.md
@@ -23,7 +23,6 @@ npm install entangle-ui @base-ui/react @floating-ui/react
 ```
 
 ```tsx
-import 'entangle-ui/styles.css';
 import { ThemeProvider, Button } from 'entangle-ui';
 
 export function App() {
@@ -34,6 +33,12 @@ export function App() {
   );
 }
 ```
+
+Component styles are bundled with each module via Vanilla Extract side-effects
+(see `sideEffects: ["*.css", "*.css.ts", "*.css.js"]` in the package's
+`package.json`). No manual stylesheet import is required — your bundler
+(Vite/Rollup/Webpack) collects the CSS automatically as components are
+imported.
 
 ## Component index
 
@@ -150,7 +155,7 @@ export function App() {
 ## Authoring rules
 
 - Always wrap the app once in the `ThemeProvider` component (defaults to dark theme).
-- Import the bundled stylesheet exactly once: `import 'entangle-ui/styles.css'`.
+- Component styles are auto-included via the package's `sideEffects` declaration; no manual `styles.css` import is needed.
 - Prefer the typed component props documented per file. Do not invent props.
 - For custom styling, read `guides/styling.md` and `guides/theming.md` before adding new styles; theme tokens are exposed as `vars.*` from `@/theme/contract.css`.
 - Components are tree-shakeable; import directly from `entangle-ui`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "entangle-ui",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "entangle-ui",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
         "@changesets/changelog-github": "^0.5.2",

--- a/src/context/KeyboardContext.tsx
+++ b/src/context/KeyboardContext.tsx
@@ -6,7 +6,14 @@ import { createContext, useContext, memo, useEffect, useCallback } from 'react';
 import { useKeyboard, isKeyPressed } from '@/hooks/useKeyboard';
 import type { KeyboardState, AllKeys } from '@/hooks/useKeyboard';
 
-const KeyboardContext = /*#__PURE__*/ createContext<KeyboardState | null>(null);
+const NEUTRAL_KEYBOARD_STATE: KeyboardState = {
+  pressedKeys: [],
+  modifiers: { control: false, shift: false, alt: false, meta: false },
+};
+
+const KeyboardContext = /*#__PURE__*/ createContext<KeyboardState>(
+  NEUTRAL_KEYBOARD_STATE
+);
 
 export interface KeyboardContextProviderProps {
   children: React.ReactNode;
@@ -23,15 +30,8 @@ export const KeyboardContextProvider = /*#__PURE__*/ memo(
   }
 );
 
-export const useKeyboardContext = (): KeyboardState => {
-  const context = useContext(KeyboardContext);
-  if (!context) {
-    throw new Error(
-      'useKeyboardContext must be used within a KeyboardContextProvider'
-    );
-  }
-  return context;
-};
+export const useKeyboardContext = (): KeyboardState =>
+  useContext(KeyboardContext);
 
 type KeyboardEffectMode = 'keydown' | 'keyup';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -497,6 +497,18 @@ export type {
   ValueOf,
 } from '@/types/utilities';
 
+// Keyboard context (auto-mounted by ThemeProvider; exported for explicit use
+// in apps that don't render a ThemeProvider at the root)
+export {
+  KeyboardContextProvider,
+  useKeyboardContext,
+  useEffectsOnKeyboard,
+} from '@/context/KeyboardContext';
+export type { KeyboardContextProviderProps } from '@/context/KeyboardContext';
+
+// Icons
+export * from '@/components/Icons';
+
 // Hooks
 export {
   useClickOutside,

--- a/src/theme/ThemeProvider.tsx
+++ b/src/theme/ThemeProvider.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect } from 'react';
 import { GLOBAL_SCROLLBARS_CLASS } from './globalScrollbars.css';
+import { KeyboardContextProvider } from '@/context/KeyboardContext';
 
 export interface ThemeProviderProps {
   children: React.ReactNode;
@@ -43,5 +44,5 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({
     };
   }, [globalScrollbars]);
 
-  return <>{children}</>;
+  return <KeyboardContextProvider>{children}</KeyboardContextProvider>;
 };


### PR DESCRIPTION
## Summary

Addresses three issues found while building the Terraforming Studio demo on
`entangle-ui@0.8.0`. Bug report — A1 (critical) was a hard crash; B1/B2 are
docs-vs-package mismatches.

### A1 — `useKeyboardContext` throws under a bare `ThemeProvider` (critical)

`Slider`, `NumberInput`, and `VectorInput` consume `useKeyboardContext`,
which threw if the context default was `null`. `KeyboardContextProvider`
existed in `src/context/KeyboardContext.tsx` but was never re-exported from
`src/index.ts`, so the documented minimal setup (`<ThemeProvider><Slider/></…>`)
crashed at mount.

Fix:

- `src/context/KeyboardContext.tsx`: default the context to a neutral state
  (no pressed keys, all modifiers `false`) and drop the `throw` from
  `useKeyboardContext`.
- `src/theme/ThemeProvider.tsx`: auto-mount `KeyboardContextProvider` so apps
  get full Shift/Ctrl awareness for free.
- `src/index.ts`: export `KeyboardContextProvider`, `useKeyboardContext`,
  `useEffectsOnKeyboard`, and `KeyboardContextProviderProps`.

### B1 — Named icons (`SaveIcon`, `PlayIcon`, …) missing from the barrel (high)

The 63 icon components live in `src/components/Icons/` and are exported from
`src/components/Icons/index.ts`, but `src/index.ts` never re-exported that
barrel. Every consumer following `reference/icons.md` got `SyntaxError: …
does not provide an export named 'SaveIcon'`.

Fix: `src/index.ts` now `export * from '@/components/Icons'`.

### B2 — Skill docs referenced a non-existent `entangle-ui/styles.css` (medium)

`package.json` `exports` has no `./styles.css` entry, and no such file is
emitted. Styles are auto-included via Vanilla Extract `sideEffects`. Updated
`SKILL.md` to drop the misleading import line and explain the side-effect
behavior instead.

## Test plan

- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm run format`
- [x] `npx vitest run` for `Slider`, `NumberInput`, `VectorInput`, `theme`, `context` — 125/125 passing
- [x] Manual smoke: render `<ThemeProvider><Slider value={0} onChange={()=>{}}/></ThemeProvider>` and confirm no crash.
- [x] Manual smoke: `import { SaveIcon } from 'entangle-ui'` resolves after build.


---
_Generated by [Claude Code](https://claude.ai/code/session_01V8EyENH1cGjHhb1bDi3tnc)_