### PR TITLE
fix(ci): add tslib as explicit devDependency to unbreak release build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "rollup-plugin-dts": "^6.3.0",
         "rollup-plugin-preserve-directives": "^0.4.0",
         "size-limit": "^12.0.0",
+        "tslib": "^2.8.1",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "vite": "^6.3.5",
@@ -7179,9 +7180,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "optional": true,
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.21.0",

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "rollup-plugin-dts": "^6.3.0",
     "rollup-plugin-preserve-directives": "^0.4.0",
     "size-limit": "^12.0.0",
+    "tslib": "^2.8.1",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vite": "^6.3.5",


### PR DESCRIPTION
## Summary

The Release/build job on `main` started failing with:

```
[!] (plugin typescript) RollupError: [plugin typescript] @rollup/plugin-typescript:
    Could not find module 'tslib', which is required by this plugin. Is it installed?
```

## Root cause

`tslib` is declared as an **optional peer dependency** of `@rollup/plugin-typescript`, not a regular dependency.

- `.github/workflows/ci.yml` (lint, build-and-test, docs) uses the npm bundled with Node 20 (10.9.x). That version auto-installs optional peer deps, so all three jobs pass cleanly — which is why every PR went green.
- `.github/workflows/release.yml` has an `npm install -g npm@latest` step before `npm ci`. That bumps npm to 11.x in CI, and the newer npm does **not** auto-install optional peer deps. `rollup -c` then aborts before `changesets/action` can publish.

So the failure was invisible on PRs and only surfaced on the post-merge release run for #73.

## Fix

Declare `tslib` as a direct `devDependency` (`^2.8.1`). The install is now deterministic across npm 10 and 11.

- `tsconfig.json` has `importHelpers` unset, so `tslib` helpers are not emitted into `dist/`. The published artifact is unchanged.
- No changeset needed — build-only infra fix, same reasoning as the Storybook-removal PR.

## Test plan

- [x] `npm ci` from a clean tree resolves `tslib` as a normal dev dep (lockfile no longer marks it `optional`/`peer`)
- [x] `npm run build` — green (`dist/esm` + `dist/types` + tokens)
- [x] `npm run lint` — clean
- [x] `npm run type-check` — clean
- [x] `npm run format:check` — clean
- [x] `npm test` — 2397/2397 (unchanged, no source touched)
- [x] `npm run docs:build` — green (896 pages)
- [ ] Watch the Release workflow on this branch's merge to confirm the build step now passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQn6Q7kDs64YbHwDYtFSNd)_