### PR TITLE
refactor(navigation): PathBar code-review refinements

### DIFF
--- a/docs-site/src/components/demos/navigation/PathBarDemo.tsx
+++ b/docs-site/src/components/demos/navigation/PathBarDemo.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, type CSSProperties } from 'react';
 import type React from 'react';
 import DemoWrapper from '../DemoWrapper';
 import { Stack } from '@/components/layout';
@@ -133,6 +133,42 @@ export function PathBarInteractive() {
         />
         <Status>current path: {path}</Status>
         <Caption>Click any folder crumb to navigate up the tree.</Caption>
+      </Stack>
+    </DemoWrapper>
+  );
+}
+
+// A localized accent palette applied purely by overriding the theme contract's
+// `--etui-*` custom properties on an ancestor — no PathBar props involved.
+const ACCENT_TOKENS: CSSProperties = {
+  ['--etui-color-text-secondary' as string]: '#7dd3fc',
+  ['--etui-color-text-primary' as string]: '#f0f9ff',
+  ['--etui-color-text-muted' as string]: '#38bdf8',
+  ['--etui-radius-sm' as string]: '6px',
+};
+
+/**
+ * Re-skinning PathBar through theme tokens: both bars are the same component
+ * with identical props — only the inherited `--etui-*` values differ.
+ */
+export function PathBarStyledViaTokens() {
+  const path = 'src/components/Button/Button.tsx';
+  return (
+    <DemoWrapper>
+      <Stack spacing={3}>
+        <Stack spacing={1}>
+          <PathBar value={path} rootIcon={<HomeIcon size="sm" decorative />} />
+          <Caption>Default theme tokens</Caption>
+        </Stack>
+        <Stack spacing={1}>
+          <div style={ACCENT_TOKENS}>
+            <PathBar
+              value={path}
+              rootIcon={<HomeIcon size="sm" decorative />}
+            />
+          </div>
+          <Caption>Custom --etui-* overrides on an ancestor</Caption>
+        </Stack>
       </Stack>
     </DemoWrapper>
   );

--- a/docs-site/src/content/docs/components/navigation/path-bar.mdx
+++ b/docs-site/src/content/docs/components/navigation/path-bar.mdx
@@ -13,6 +13,7 @@ import PathBarDemo, {
   PathBarSizes,
   PathBarInteractive,
   PathBarSiblingDropdown,
+  PathBarStyledViaTokens,
 } from '../../../../components/demos/navigation/PathBarDemo';
 
 PathBar turns a file path into clickable breadcrumb segments, like the VS Code editor breadcrumb bar. It is a thin specialization of [Breadcrumbs](/components/navigation/breadcrumbs): give it a path — a delimited string or a structured segment array — and it renders each segment as a crumb, leaning on Breadcrumbs for separators, overflow collapsing, and accessibility.
@@ -86,7 +87,7 @@ Provide `getSiblings` to add a VS-Code-style dropdown to each crumb. Return the 
 />
 ```
 
-`getSiblings` is called during render for each segment, so keep it cheap (an array or map lookup) — or memoize the underlying data. Each crumb with a non-empty result gains a chevron caret that opens a [Menu](/components/navigation/menu) of siblings; the crumb label still navigates on click.
+`getSiblings` is called during render for each **visible** crumb (segments hidden behind the overflow ellipsis are skipped until expanded), so keep it cheap — an array or map lookup — or memoize the underlying data. Each crumb with a non-empty result gains a chevron caret that opens a [Menu](/components/navigation/menu) of siblings; the crumb label still navigates on click.
 
 ## Icons
 
@@ -147,6 +148,46 @@ PathBar reuses the Breadcrumbs collapse machinery. When `maxItems` is greater th
 <PathBar size="md" value="src/components/Button.tsx" />
 <PathBar size="lg" value="src/components/Button.tsx" />
 ```
+
+`size` scales the typography, the default chevron separator, and the sibling-dropdown caret together.
+
+## Styling
+
+Every color, radius, and transition in PathBar reads from the `--etui-*` theme-contract custom properties — most of them inherited from [Breadcrumbs](/components/navigation/breadcrumbs). To re-skin a bar (or a whole subtree of your app) override those variables on any ancestor element; no component-level props required.
+
+<ComponentPreview title="Default vs. custom token overrides">
+  <PathBarStyledViaTokens client:only="react" />
+</ComponentPreview>
+
+```tsx
+import type { CSSProperties } from 'react';
+
+const accent: CSSProperties = {
+  '--etui-color-text-secondary': '#7dd3fc', // folder crumbs
+  '--etui-color-text-primary': '#f0f9ff', // current segment + hover
+  '--etui-color-text-muted': '#38bdf8', // separators + idle caret
+  '--etui-radius-sm': '6px', // focus-ring / caret corners
+};
+
+<div style={accent}>
+  <PathBar value="src/components/Button/Button.tsx" />
+</div>;
+```
+
+The tokens PathBar reads:
+
+| Token                                           | Affects                                             |
+| ----------------------------------------------- | --------------------------------------------------- |
+| `--etui-color-text-secondary`                   | Folder (clickable) crumbs.                          |
+| `--etui-color-text-primary`                     | Current segment, crumb hover, and the active caret. |
+| `--etui-color-text-muted`                       | Separators and the idle sibling-dropdown caret.     |
+| `--etui-shadow-focus`                           | Focus ring on crumbs and the caret button.          |
+| `--etui-radius-sm`                              | Focus-ring and caret corner radius.                 |
+| `--etui-spacing-xs`, `--etui-spacing-sm`        | Gap between crumbs and the caret offset.            |
+| `--etui-transition-fast`                        | Hover / focus color transitions.                    |
+| `--etui-font-family-sans`, `--etui-font-size-*` | Bar typography (the `size` prop selects the step).  |
+
+For a fully custom palette across the whole app, prefer `createCustomTheme(...)` from the public API — overriding `--etui-*` directly is the right tool for a localized accent.
 
 ## Paths
 
@@ -214,8 +255,9 @@ Use PathBar for file-system-flavored locations: editor breadcrumb bars, asset pa
     {
       name: 'separator',
       type: 'ReactNode',
-      default: '<ChevronRightIcon size="sm" decorative />',
-      description: 'Separator inserted between segments.',
+      default: '<ChevronRightIcon size={size} decorative />',
+      description:
+        'Separator inserted between segments. The default chevron scales with `size`.',
     },
     {
       name: 'maxItems',
@@ -246,7 +288,8 @@ Use PathBar for file-system-flavored locations: editor breadcrumb bars, asset pa
       name: 'size',
       type: "'sm' | 'md' | 'lg'",
       default: "'sm'",
-      description: 'Typography and spacing scale.',
+      description:
+        'Typography and spacing scale. Also scales the default separator and the sibling-dropdown caret.',
     },
     {
       name: 'className',

--- a/src/components/navigation/PathBar/PathBar.tsx
+++ b/src/components/navigation/PathBar/PathBar.tsx
@@ -1,48 +1,23 @@
 'use client';
 
-import React, { useCallback, useMemo } from 'react';
+import React, { useMemo } from 'react';
 
-import { ChevronDownIcon, ChevronRightIcon } from '@/components/Icons';
+import { ChevronRightIcon } from '@/components/Icons';
 import {
   Breadcrumbs,
   BreadcrumbItem,
 } from '@/components/navigation/Breadcrumbs';
-import { Menu } from '@/components/navigation/Menu';
-import { IconButton } from '@/components/primitives';
 import { useControlledState, useLatest } from '@/hooks';
 
-import { pathBarSiblingTriggerStyle } from './PathBar.css';
-import { normalizePath, segmentPrefix } from './pathUtils';
+import { PathBarSiblingMenu } from './PathBarSiblingMenu';
+import { normalizePath } from './pathUtils';
 
-import type { PathBarProps, PathSegment } from './PathBar.types';
+import type { PathBarProps } from './PathBar.types';
 import type { ResolvedPathSegment } from './pathUtils';
 
-const EMPTY_SEGMENTS: ResolvedPathSegment[] = [];
-
-/**
- * Resolve a `getSiblings` result into segments with concrete navigation
- * values. A sibling lives in the same parent as `segments[index]`, so it
- * inherits that segment's prefix and only swaps the trailing label.
- */
-function resolveSiblings(
-  segments: readonly ResolvedPathSegment[],
-  index: number,
-  entries: ReadonlyArray<string | PathSegment>
-): ResolvedPathSegment[] {
-  const anchor = segments[index];
-  if (!anchor) {
-    return EMPTY_SEGMENTS;
-  }
-  const prefix = segmentPrefix(anchor);
-  return entries.map(entry => {
-    const segment: PathSegment =
-      typeof entry === 'string' ? { label: entry } : entry;
-    return {
-      ...segment,
-      value: segment.value ?? prefix + segment.label,
-    };
-  });
-}
+// Frozen so the shared fallback can never be mutated in place; every write path
+// builds a fresh array via slice/spread.
+const EMPTY_SEGMENTS: readonly ResolvedPathSegment[] = Object.freeze([]);
 
 /**
  * File-path breadcrumbs, like the VS Code editor breadcrumb bar.
@@ -85,6 +60,8 @@ export const PathBar = ({
   ref,
   ...rest
 }: PathBarProps): React.ReactElement => {
+  // Wrap the consumer callback so navigation handlers don't depend on its
+  // (typically inline, render-fresh) identity.
   const onNavigateRef = useLatest(onNavigate);
 
   const controlledSegments = useMemo(
@@ -99,76 +76,38 @@ export const PathBar = ({
     [defaultValue, delimiter]
   );
 
-  const [segments, setSegments] = useControlledState<ResolvedPathSegment[]>({
+  const [segments, setSegments] = useControlledState<
+    readonly ResolvedPathSegment[]
+  >({
     value: controlledSegments,
     defaultValue: defaultSegments,
     fallback: EMPTY_SEGMENTS,
   });
 
-  // Read the live trail from a ref so the handlers stay identity-stable and
-  // never go stale, even though the rendered crumbs change every navigation.
-  const segmentsRef = useLatest(segments);
+  // Handlers are invoked only from the crumb-mapping below (recreated every
+  // render anyway), so they close over the current-render `segments` directly —
+  // no ref indirection needed, and the value is always live at click time.
+  const navigateToIndex = (index: number): void => {
+    const target = segments[index];
+    if (!target) {
+      return;
+    }
+    // Navigating to an ancestor drops everything below it (uncontrolled mode;
+    // a controlled `value` is left untouched and driven by the consumer).
+    setSegments(segments.slice(0, index + 1));
+    onNavigateRef.current?.(target.value, target, index);
+  };
 
-  const navigateToIndex = useCallback(
-    (index: number) => {
-      const target = segmentsRef.current[index];
-      if (!target) {
-        return;
-      }
-      // Navigating to an ancestor drops everything below it (uncontrolled mode;
-      // a controlled `value` is left untouched and driven by the consumer).
-      setSegments(segmentsRef.current.slice(0, index + 1));
-      onNavigateRef.current?.(target.value, target, index);
-    },
-    [segmentsRef, setSegments, onNavigateRef]
-  );
-
-  const selectSibling = useCallback(
-    (index: number, sibling: ResolvedPathSegment) => {
-      // A lateral move: keep the ancestors, swap this segment, drop anything
-      // deeper since the old subtree no longer applies.
-      setSegments([...segmentsRef.current.slice(0, index), sibling]);
-      onNavigateRef.current?.(sibling.value, sibling, index);
-    },
-    [segmentsRef, setSegments, onNavigateRef]
-  );
+  const selectSibling = (index: number, sibling: ResolvedPathSegment): void => {
+    // A lateral move: keep the ancestors, swap this segment, drop anything
+    // deeper since the old subtree no longer applies.
+    setSegments([...segments.slice(0, index), sibling]);
+    onNavigateRef.current?.(sibling.value, sibling, index);
+  };
 
   const items = segments.map((segment, index) => {
     const isLast = index === segments.length - 1;
     const icon = segment.icon ?? (index === 0 ? rootIcon : undefined);
-
-    const rawSiblings = getSiblings?.(segment, index) ?? [];
-    const siblings = resolveSiblings(segments, index, rawSiblings);
-    const endContent =
-      siblings.length > 0 ? (
-        <Menu>
-          <Menu.Trigger
-            render={
-              <IconButton
-                aria-label={`Browse ${segment.label} siblings`}
-                size="sm"
-                radius="sm"
-                className={pathBarSiblingTriggerStyle}
-              >
-                <ChevronDownIcon size="sm" decorative />
-              </IconButton>
-            }
-          />
-          <Menu.Content>
-            {siblings.map((sibling, siblingIndex) => (
-              <Menu.Item
-                key={`${sibling.value}-${siblingIndex}`}
-                icon={sibling.icon}
-                onSelect={() => {
-                  selectSibling(index, sibling);
-                }}
-              >
-                {sibling.label}
-              </Menu.Item>
-            ))}
-          </Menu.Content>
-        </Menu>
-      ) : undefined;
 
     return (
       <BreadcrumbItem
@@ -182,7 +121,17 @@ export const PathBar = ({
                 navigateToIndex(index);
               }
         }
-        endContent={endContent}
+        endContent={
+          getSiblings ? (
+            <PathBarSiblingMenu
+              segment={segment}
+              index={index}
+              getSiblings={getSiblings}
+              onSelect={selectSibling}
+              size={size}
+            />
+          ) : undefined
+        }
       >
         {segment.label}
       </BreadcrumbItem>
@@ -192,7 +141,7 @@ export const PathBar = ({
   return (
     <Breadcrumbs
       ref={ref}
-      separator={separator ?? <ChevronRightIcon size="sm" decorative />}
+      separator={separator ?? <ChevronRightIcon size={size} decorative />}
       maxItems={maxItems}
       itemsBeforeCollapse={itemsBeforeCollapse}
       itemsAfterCollapse={itemsAfterCollapse}

--- a/src/components/navigation/PathBar/PathBar.types.ts
+++ b/src/components/navigation/PathBar/PathBar.types.ts
@@ -1,4 +1,7 @@
-import type { BreadcrumbsSize } from '@/components/navigation/Breadcrumbs';
+import type {
+  BreadcrumbsProps,
+  BreadcrumbsSize,
+} from '@/components/navigation/Breadcrumbs';
 import type { BaseComponent } from '@/types/common';
 import type { Prettify } from '@/types/utilities';
 import type React from 'react';
@@ -30,10 +33,15 @@ export interface PathSegment {
  */
 export type PathInput = string | ReadonlyArray<string | PathSegment>;
 
-export interface PathBarBaseProps extends Omit<
-  BaseComponent<HTMLElement>,
-  'onChange' | 'defaultValue'
-> {
+export interface PathBarBaseProps
+  extends
+    Omit<BaseComponent<HTMLElement>, 'onChange' | 'defaultValue'>,
+    // Overflow-collapse behavior is delegated verbatim to Breadcrumbs, so the
+    // props (and their docs) are sourced from there rather than duplicated.
+    Pick<
+      BreadcrumbsProps,
+      'maxItems' | 'itemsBeforeCollapse' | 'itemsAfterCollapse' | 'expandable'
+    > {
   /**
    * Controlled current path. When provided, PathBar renders exactly this path
    * and never mutates it — drive changes from `onNavigate`.
@@ -79,38 +87,15 @@ export interface PathBarBaseProps extends Omit<
   rootIcon?: React.ReactNode;
 
   /**
-   * Separator inserted between segments.
-   * @default <ChevronRightIcon size="sm" decorative />
+   * Separator inserted between segments. The default chevron scales with
+   * `size`.
+   * @default <ChevronRightIcon size={size} decorative />
    */
   separator?: React.ReactNode;
 
   /**
-   * Maximum number of segments to show before collapsing the middle into an
-   * ellipsis. `0` never collapses.
-   * @default 0
-   */
-  maxItems?: number;
-
-  /**
-   * Segments to keep visible at the start when collapsing.
-   * @default 1
-   */
-  itemsBeforeCollapse?: number;
-
-  /**
-   * Segments to keep visible at the end when collapsing.
-   * @default 2
-   */
-  itemsAfterCollapse?: number;
-
-  /**
-   * Render the ellipsis as a button that expands the collapsed segments.
-   * @default true
-   */
-  expandable?: boolean;
-
-  /**
-   * Typography and spacing scale.
+   * Typography and spacing scale. Also scales the default separator and the
+   * sibling-dropdown caret.
    * @default "sm"
    */
   size?: PathBarSize;

--- a/src/components/navigation/PathBar/PathBarSiblingMenu.tsx
+++ b/src/components/navigation/PathBar/PathBarSiblingMenu.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import React from 'react';
+
+import { ChevronDownIcon } from '@/components/Icons';
+import { Menu } from '@/components/navigation/Menu';
+import { IconButton } from '@/components/primitives';
+
+import { pathBarSiblingTriggerStyle } from './PathBar.css';
+import { resolveSiblings } from './pathUtils';
+
+import type { PathBarSize, PathSegment } from './PathBar.types';
+import type { ResolvedPathSegment } from './pathUtils';
+
+interface PathBarSiblingMenuProps {
+  /** The resolved segment this dropdown hangs off — the sibling anchor. */
+  segment: ResolvedPathSegment;
+  /** Index of `segment` in the trail; forwarded to `onSelect`. */
+  index: number;
+  /** Returns the raw sibling entries for the segment. */
+  getSiblings: (
+    segment: PathSegment,
+    index: number
+  ) => ReadonlyArray<string | PathSegment>;
+  /** Called with the chosen sibling (already resolved to a concrete value). */
+  onSelect: (index: number, sibling: ResolvedPathSegment) => void;
+  /** Scale shared with the rest of the bar — sizes the caret button and icon. */
+  size: PathBarSize;
+}
+
+/**
+ * Trailing caret + dropdown for a single crumb's siblings (the VS Code path-bar
+ * affordance). Rendered as a crumb's `endContent`, so it mounts only for crumbs
+ * Breadcrumbs actually renders — `getSiblings` runs lazily, never for segments
+ * hidden behind the overflow ellipsis. Renders nothing when the segment has no
+ * siblings.
+ */
+export const PathBarSiblingMenu = ({
+  segment,
+  index,
+  getSiblings,
+  onSelect,
+  size,
+}: PathBarSiblingMenuProps): React.ReactElement | null => {
+  const siblings = resolveSiblings(segment, getSiblings(segment, index));
+  if (siblings.length === 0) {
+    return null;
+  }
+
+  return (
+    <Menu>
+      <Menu.Trigger
+        render={
+          <IconButton
+            aria-label={`Browse ${segment.label} siblings`}
+            size={size}
+            radius="sm"
+            className={pathBarSiblingTriggerStyle}
+          >
+            <ChevronDownIcon size={size} decorative />
+          </IconButton>
+        }
+      />
+      <Menu.Content>
+        {siblings.map((sibling, siblingIndex) => (
+          <Menu.Item
+            key={`${sibling.value}-${siblingIndex}`}
+            icon={sibling.icon}
+            onSelect={() => {
+              onSelect(index, sibling);
+            }}
+          >
+            {sibling.label}
+          </Menu.Item>
+        ))}
+      </Menu.Content>
+    </Menu>
+  );
+};
+
+PathBarSiblingMenu.displayName = 'PathBarSiblingMenu';

--- a/src/components/navigation/PathBar/pathUtils.test.ts
+++ b/src/components/navigation/PathBar/pathUtils.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import { joinPath, normalizePath, parsePath, segmentPrefix } from './pathUtils';
+import {
+  joinPath,
+  normalizePath,
+  parsePath,
+  resolveSiblings,
+  segmentPrefix,
+} from './pathUtils';
 
 import type { ResolvedPathSegment } from './pathUtils';
 
@@ -114,5 +120,45 @@ describe('normalizePath', () => {
       { label: 'example', value: 'com.example' },
       { label: 'app', value: 'com.example.app' },
     ]);
+  });
+});
+
+describe('resolveSiblings', () => {
+  it('derives sibling values from the anchor prefix', () => {
+    const anchor: ResolvedPathSegment = {
+      label: 'Button.tsx',
+      value: 'src/components/Button.tsx',
+    };
+    expect(resolveSiblings(anchor, ['Input.tsx', 'Card.tsx'])).toEqual([
+      { label: 'Input.tsx', value: 'src/components/Input.tsx' },
+      { label: 'Card.tsx', value: 'src/components/Card.tsx' },
+    ]);
+  });
+
+  it('keeps the leading delimiter for absolute anchors', () => {
+    const anchor: ResolvedPathSegment = { label: 'local', value: '/usr/local' };
+    expect(resolveSiblings(anchor, ['bin'])).toEqual([
+      { label: 'bin', value: '/usr/bin' },
+    ]);
+  });
+
+  it('resolves siblings of a relative root against an empty prefix', () => {
+    const anchor: ResolvedPathSegment = { label: 'src', value: 'src' };
+    expect(resolveSiblings(anchor, ['public'])).toEqual([
+      { label: 'public', value: 'public' },
+    ]);
+  });
+
+  it('preserves an explicit value and icon on a structured sibling', () => {
+    const anchor: ResolvedPathSegment = { label: 'b', value: 'a/b' };
+    const icon = 'icon';
+    expect(
+      resolveSiblings(anchor, [{ label: 'c', value: 'custom', icon }])
+    ).toEqual([{ label: 'c', value: 'custom', icon }]);
+  });
+
+  it('returns an empty array when there are no entries', () => {
+    const anchor: ResolvedPathSegment = { label: 'src', value: 'src' };
+    expect(resolveSiblings(anchor, [])).toEqual([]);
   });
 });

--- a/src/components/navigation/PathBar/pathUtils.ts
+++ b/src/components/navigation/PathBar/pathUtils.ts
@@ -60,6 +60,13 @@ export function joinPath(
  * segmentPrefix({ label: 'src', value: '/src' })       // '/'
  * segmentPrefix({ label: 'b', value: 'a/b' })           // 'a/'
  * segmentPrefix({ label: 'src', value: 'src' })         // ''
+ *
+ * @remarks
+ * Assumes `value` ends with `label` — always true for parsed paths and for
+ * cumulative array values. If a consumer supplies a structured segment whose
+ * `value` is unrelated to its `label`, the derived prefix is meaningless; in
+ * that case provide explicit `value`s on that segment's siblings too so they
+ * don't fall back to this prefix.
  */
 export function segmentPrefix(segment: ResolvedPathSegment): string {
   return segment.value.slice(0, segment.value.length - segment.label.length);
@@ -117,6 +124,30 @@ export function normalizePath(
     return {
       ...segment,
       value: segment.value ?? joinPath(labels, index, delimiter),
+    };
+  });
+}
+
+/**
+ * Resolve a `getSiblings` result into segments with concrete navigation
+ * values. A sibling lives in the same parent as `anchor`, so it inherits that
+ * segment's prefix (see {@link segmentPrefix}) and only swaps the trailing
+ * label. Entries that already carry an explicit `value` keep it.
+ *
+ * @param anchor  The resolved segment the siblings sit beside.
+ * @param entries Raw sibling entries — plain labels or structured segments.
+ */
+export function resolveSiblings(
+  anchor: ResolvedPathSegment,
+  entries: ReadonlyArray<string | PathSegment>
+): ResolvedPathSegment[] {
+  const prefix = segmentPrefix(anchor);
+  return entries.map(entry => {
+    const segment: PathSegment =
+      typeof entry === 'string' ? { label: entry } : entry;
+    return {
+      ...segment,
+      value: segment.value ?? prefix + segment.label,
     };
   });
 }


### PR DESCRIPTION
Superseded — the PathBar code-review refinements were fast-forwarded directly onto `etui-pathbar` (commit `04d09a5`), so they now live in the existing PR #94. Closing this redundant PR.

https://claude.ai/code/session_01NGZhUmxkCFrYwwBr8d47HJ