### PR TITLE
ci: deploy docs only after a release (not on every main push) + version badge

### DIFF
--- a/.changeset/cuddly-facts-drive.md
+++ b/.changeset/cuddly-facts-drive.md
@@ -1,0 +1,8 @@
+---
+---
+
+ci: deploy the docs site after a successful release (or manually) instead of on
+every push to `main`, and show the released package version in the docs header.
+
+Infrastructure-only change — no effect on the published `entangle-ui` package,
+so this changeset intentionally bumps nothing.

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,13 +1,22 @@
 name: Deploy Docs
 
+# Docs are NOT deployed on every push to main — main only accumulates
+# changesets between releases. The site is published either manually
+# (workflow_dispatch) or by the Release workflow once a real release has
+# been published to npm (workflow_call). See .github/workflows/release.yml.
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   deploy-docs:
     runs-on: ubuntu-latest
+
+    # Serialize deployments so a manual run and a release-triggered run can't
+    # race each other onto GitHub Pages.
+    concurrency:
+      group: deploy-docs
+      cancel-in-progress: false
 
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,9 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
+    outputs:
+      published: ${{ steps.changesets.outputs.published }}
+      published-packages: ${{ steps.changesets.outputs.publishedPackages }}
 
     steps:
       - name: Checkout
@@ -93,3 +96,16 @@ jobs:
         run: |
           echo "## Packages Released" >> $GITHUB_STEP_SUMMARY
           echo '${{ steps.changesets.outputs.publishedPackages }}' | jq -r '.[] | "- **\(.name)** @ `\(.version)`"' >> $GITHUB_STEP_SUMMARY
+
+  # Publish the documentation site, but only after an actual npm release.
+  # Plain pushes to main just update the pending "Version Packages" PR
+  # (published == 'false'), so they must not trigger a docs deployment.
+  deploy-docs:
+    name: Deploy Docs
+    needs: release
+    if: needs.release.outputs.published == 'true'
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    uses: ./.github/workflows/docs.yaml

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -15,6 +15,7 @@ export default defineConfig({
       description: 'React component library for professional editor interfaces',
       components: {
         Hero: './src/components/overrides/Hero.astro',
+        SiteTitle: './src/components/overrides/SiteTitle.astro',
       },
       social: [
         {

--- a/docs-site/src/components/overrides/SiteTitle.astro
+++ b/docs-site/src/components/overrides/SiteTitle.astro
@@ -1,0 +1,47 @@
+---
+// Renders Starlight's default site title and appends a version badge so the
+// docs always advertise the package version they were built from. The version
+// is read from the library's root package.json at build time, which the
+// Release workflow has already bumped by the time the docs are deployed.
+import Default from '@astrojs/starlight/components/SiteTitle.astro';
+import pkg from '../../../../package.json';
+
+const version = `v${pkg.version}`;
+const releasesHref = 'https://github.com/SebastianWebdev/entangle-ui/releases';
+---
+
+<Default {...Astro.props} />
+
+<a
+  class="version-badge"
+  href={releasesHref}
+  target="_blank"
+  rel="noopener noreferrer"
+  title={`Entangle UI ${version} — view releases on GitHub`}
+>
+  {version}
+</a>
+
+<style>
+  .version-badge {
+    align-self: center;
+    flex-shrink: 0;
+    margin-inline-start: 0.5rem;
+    padding: 0.05rem 0.4rem;
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 999rem;
+    background: var(--sl-color-gray-6);
+    color: var(--sl-color-gray-2);
+    font-family: var(--sl-font-system-mono);
+    font-size: var(--sl-text-xs);
+    line-height: 1.5;
+    text-decoration: none;
+    white-space: nowrap;
+    transition: color 0.15s ease, border-color 0.15s ease;
+  }
+
+  .version-badge:hover {
+    color: var(--sl-color-text-accent);
+    border-color: var(--sl-color-text-accent);
+  }
+</style>


### PR DESCRIPTION
## Problem

The **Deploy Docs** workflow triggered on every `push` to `main`, so the docs
site was republished whenever changes landed on `main`. But `main` only
*accumulates* changesets between releases — the actual npm release happens later,
when the "Version Packages" PR is merged. The result was docs going live ahead of
(and out of sync with) the released package.

## Change

Decouple the docs deploy from `main` pushes — it now runs **manually** or **after
a real release**.

- **`.github/workflows/docs.yaml`**
  - Drop the `push: branches: [main]` trigger.
  - Keep `workflow_dispatch` (manual) and add `workflow_call` so the Release
    workflow can invoke it.
  - Add a `deploy-docs` concurrency group so a manual run and a release-triggered
    run can't race each other onto GitHub Pages.
- **`.github/workflows/release.yml`**
  - Expose the changesets `published` output from the `release` job.
  - Add a `deploy-docs` job that calls `docs.yaml` **only when an actual npm
    publish happened** (`if: needs.release.outputs.published == 'true'`). Plain
    pushes to `main` (which just update the pending Version Packages PR, where
    `published == 'false'`) no longer deploy.

### Resulting behavior

| Event on `main`                                   | `published` | Docs deploy |
| ------------------------------------------------- | ----------- | ----------- |
| Feature PR merged (adds a changeset)              | `false`     | ❌ no        |
| "Version Packages" PR merged → npm publish        | `true`      | ✅ yes       |
| Manual `workflow_dispatch` on **Deploy Docs**     | —           | ✅ yes       |

## Bonus: docs advertise the released version ⭐

The task's stretch goal ("docs should point to the current version number").

- **`docs-site/src/components/overrides/SiteTitle.astro`** (new) — a Starlight
  `SiteTitle` override that renders the default title plus a version badge read
  from the root `package.json` at build time. Because the docs only deploy *after*
  a release, the checked-out `package.json` is already bumped, so the badge shows
  the just-released version (e.g. `v0.9.0`) and links to the GitHub releases page.
- Registered via `components.SiteTitle` in `docs-site/astro.config.mjs`.

## Notes

- Ships with an **empty changeset** — this is infra/docs only and does not affect
  the published `entangle-ui` artifact, so it intentionally bumps nothing.
- `ci.yml` still builds the docs on every PR/push as a validation step; only the
  *deploy* is gated.

## Verification

- `npm run lint`, `npm run type-check`, `npm run format:check` — pass.
- Full `docs-site` build (`npm run build`) succeeds; the badge renders globally,
  e.g. `<a class="version-badge" … title="Entangle UI v0.9.0 …">v0.9.0</a>`.

https://claude.ai/code/session_01E1td2rv6RmFgYGYqfjoBmV

---
_Generated by [Claude Code](https://claude.ai/code/session_01E1td2rv6RmFgYGYqfjoBmV)_