### PR TITLE
feat(docs): version the documentation site per release

### DIFF
--- a/.changeset/docs-versioning.md
+++ b/.changeset/docs-versioning.md
@@ -1,0 +1,8 @@
+---
+---
+
+ci(docs): version the documentation site. Each release now publishes the latest
+docs at the site root and an immutable snapshot under /vMAJOR.MINOR/, accumulated
+on a `docs-versions` branch, with a runtime version switcher in the header.
+
+Infrastructure-only change — no effect on the published `entangle-ui` package.

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -4,6 +4,14 @@ name: Deploy Docs
 # changesets between releases. The site is published either manually
 # (workflow_dispatch) or by the Release workflow once a real release has
 # been published to npm (workflow_call). See .github/workflows/release.yml.
+#
+# Each deploy publishes two things into a single GitHub Pages artifact:
+#   • the "latest" docs at the site root (/)
+#   • an immutable snapshot of this release under /vMAJOR.MINOR/
+# Snapshots are accumulated on the `docs-versions` branch (a durable store,
+# since Pages/Actions artifacts expire) and re-assembled on every deploy, so
+# previously released versions stay available. A runtime /versions.json drives
+# the in-header version switcher.
 on:
   workflow_dispatch:
   workflow_call:
@@ -13,19 +21,22 @@ jobs:
     runs-on: ubuntu-latest
 
     # Serialize deployments so a manual run and a release-triggered run can't
-    # race each other onto GitHub Pages.
+    # race each other onto GitHub Pages or the version-archive branch.
     concurrency:
       group: deploy-docs
       cancel-in-progress: false
 
     permissions:
-      contents: read
+      contents: write # push version snapshots to the docs-versions branch
       pages: write
       id-token: write
 
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+
+    env:
+      VERSIONS_BRANCH: docs-versions
 
     steps:
       - name: Checkout code
@@ -43,8 +54,67 @@ jobs:
       - name: Install docs dependencies
         run: cd docs-site && npm install
 
-      - name: Build docs site
-        run: cd docs-site && npm run build
+      - name: Determine version slug
+        id: version
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          SLUG="v$(echo "$VERSION" | cut -d. -f1-2)"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "slug=$SLUG" >> "$GITHUB_OUTPUT"
+          echo "Building docs for $VERSION (snapshot slug: $SLUG)"
+
+      - name: Build latest docs (site root)
+        run: |
+          ( cd docs-site && npm run build )
+          rm -rf site
+          mv docs-site/dist site
+
+      - name: Build versioned snapshot
+        run: ( cd docs-site && DOCS_BASE="/${{ steps.version.outputs.slug }}" npm run build )
+
+      - name: Archive snapshot on the docs-versions branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SLUG: ${{ steps.version.outputs.slug }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          AUTH_REPO="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          rm -rf storage
+          if git clone --quiet --depth 1 --branch "$VERSIONS_BRANCH" "$AUTH_REPO" storage 2>/dev/null; then
+            echo "Cloned existing $VERSIONS_BRANCH branch"
+          else
+            echo "Branch $VERSIONS_BRANCH not found — creating it"
+            rm -rf storage && mkdir storage
+            git -C storage init --quiet
+            git -C storage checkout --quiet --orphan "$VERSIONS_BRANCH"
+            git -C storage remote add origin "$AUTH_REPO"
+          fi
+          rm -rf "storage/$SLUG"
+          mkdir -p "storage/$SLUG"
+          cp -a docs-site/dist/. "storage/$SLUG/"
+          git -C storage add -A
+          git -C storage \
+            -c user.name='github-actions[bot]' \
+            -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+            commit --quiet -m "docs: snapshot $SLUG ($VERSION)" \
+            || echo "No documentation changes to archive for $SLUG"
+          git -C storage push --quiet origin "HEAD:$VERSIONS_BRANCH"
+
+      - name: Assemble multi-version site
+        run: |
+          set -euo pipefail
+          # `site/` already holds the latest build at the root. Layer every
+          # archived snapshot under its /vMAJOR.MINOR/ sub-path.
+          for dir in storage/v*/; do
+            [ -d "$dir" ] || continue
+            dir="${dir%/}"
+            slug="$(basename "$dir")"
+            rm -rf "site/$slug"
+            cp -a "$dir" "site/$slug"
+          done
+          node docs-site/scripts/generate-versions-json.mjs \
+            storage site/versions.json "${{ steps.version.outputs.slug }}"
 
       - name: Setup Pages
         uses: actions/configure-pages@v4
@@ -52,7 +122,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: './docs-site/dist'
+          path: ./site
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
     needs: release
     if: needs.release.outputs.published == 'true'
     permissions:
-      contents: read
+      contents: write # docs deploy archives version snapshots to a branch
       pages: write
       id-token: write
     uses: ./.github/workflows/docs.yaml

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -5,10 +5,23 @@ import starlightTypeDoc, { typeDocSidebarGroup } from 'starlight-typedoc';
 import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
 import { resolve } from 'path';
 import { fileURLToPath } from 'node:url';
+import rehypeBaseInternalLinks from './scripts/rehype-base-internal-links.mjs';
 
 const rootDir = fileURLToPath(new URL('..', import.meta.url));
 
+// When building an archived version snapshot, DOCS_BASE is set to e.g. "/v0.9"
+// so every asset and internal link resolves under that sub-path on GitHub
+// Pages. The "latest" build leaves it unset and is served from the site root.
+const base = process.env.DOCS_BASE || undefined;
+
 export default defineConfig({
+  site: 'https://www.entangle-ui.dev',
+  base,
+  // Versioned snapshot builds (DOCS_BASE set) need root-absolute Markdown links
+  // rewritten to live under the base; the root "latest" build skips this.
+  markdown: {
+    rehypePlugins: base ? [[rehypeBaseInternalLinks, { base }]] : [],
+  },
   integrations: [
     starlight({
       title: 'Entangle UI',

--- a/docs-site/scripts/generate-versions-json.mjs
+++ b/docs-site/scripts/generate-versions-json.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+/**
+ * Generates the `/versions.json` manifest consumed by the VersionSwitcher.
+ *
+ * Scans the version-archive directory for `vMAJOR.MINOR` snapshot folders and
+ * emits a manifest where the newest release (the `latest` slug) is served from
+ * the site root (`/`) and every older snapshot from its own `/vX.Y/` sub-path.
+ *
+ * Usage:
+ *   node generate-versions-json.mjs <versionsDir> <outFile> <latestSlug>
+ */
+import { readdirSync, writeFileSync, existsSync } from 'node:fs';
+
+const [, , versionsDir, outFile, latestSlug] = process.argv;
+
+if (!versionsDir || !outFile || !latestSlug) {
+  console.error(
+    'Usage: generate-versions-json.mjs <versionsDir> <outFile> <latestSlug>'
+  );
+  process.exit(1);
+}
+
+const slugPattern = /^v(\d+)\.(\d+)(?:\.(\d+))?$/;
+
+const slugs = existsSync(versionsDir)
+  ? readdirSync(versionsDir, { withFileTypes: true })
+      .filter(entry => entry.isDirectory() && slugPattern.test(entry.name))
+      .map(entry => entry.name)
+  : [];
+
+// The latest release should always appear, even before its snapshot lands.
+if (!slugs.includes(latestSlug)) slugs.push(latestSlug);
+
+const toTuple = slug => {
+  const match = slugPattern.exec(slug);
+  return [Number(match[1]), Number(match[2]), Number(match[3] ?? 0)];
+};
+
+slugs.sort((a, b) => {
+  const [aMajor, aMinor, aPatch] = toTuple(a);
+  const [bMajor, bMinor, bPatch] = toTuple(b);
+  return bMajor - aMajor || bMinor - aMinor || bPatch - aPatch;
+});
+
+const versions = slugs.map(slug => {
+  const isLatest = slug === latestSlug;
+  return { label: slug, base: isLatest ? '/' : `/${slug}/`, latest: isLatest };
+});
+
+writeFileSync(
+  outFile,
+  `${JSON.stringify({ latest: latestSlug, versions }, null, 2)}\n`
+);
+
+console.log(
+  `Wrote ${outFile} with ${versions.length} version(s): ${versions
+    .map(v => v.label)
+    .join(', ')}`
+);

--- a/docs-site/scripts/rehype-base-internal-links.mjs
+++ b/docs-site/scripts/rehype-base-internal-links.mjs
@@ -1,0 +1,51 @@
+/**
+ * Rehype plugin that prefixes root-absolute internal links (`/foo`) with the
+ * configured Astro `base` (e.g. `/v0.9`).
+ *
+ * Astro base-prefixes assets and Starlight's own navigation, but it does NOT
+ * rewrite root-absolute links written inside Markdown/MDX content (including
+ * the thousands of links in the generated TypeDoc API reference). Without this,
+ * an archived version snapshot served from `/v0.9/` would link back out to the
+ * site root (the "latest" docs), breaking the "stay inside this version" UX.
+ *
+ * Only active when `base` is set (i.e. for versioned snapshot builds); the
+ * "latest" root build leaves links untouched.
+ *
+ * Skips: external/protocol-relative URLs, `mailto:`/`tel:`/etc., in-page
+ * fragments, and links already prefixed with the base.
+ *
+ * @param {{ base?: string }} options
+ */
+export default function rehypeBaseInternalLinks(options = {}) {
+  const base = (options.base || '').replace(/\/$/, '');
+
+  return tree => {
+    if (!base) return;
+
+    const prefix = href => {
+      if (typeof href !== 'string' || href.length === 0) return href;
+      // Skip protocol/protocol-relative/special and non-root-absolute links.
+      if (!href.startsWith('/') || href.startsWith('//')) return href;
+      // Skip links already living under the base (e.g. `/v0.9` or `/v0.9/x`).
+      if (href === base || href.startsWith(`${base}/`)) return href;
+      return base + href;
+    };
+
+    const walk = node => {
+      if (node.type === 'element' && node.properties) {
+        if (node.tagName === 'a' && node.properties.href != null) {
+          node.properties.href = prefix(node.properties.href);
+        }
+        // Cover source-set style attributes too, in case content embeds them.
+        if (node.tagName === 'area' && node.properties.href != null) {
+          node.properties.href = prefix(node.properties.href);
+        }
+      }
+      if (Array.isArray(node.children)) {
+        for (const child of node.children) walk(child);
+      }
+    };
+
+    walk(tree);
+  };
+}

--- a/docs-site/src/components/VersionSwitcher.tsx
+++ b/docs-site/src/components/VersionSwitcher.tsx
@@ -1,0 +1,109 @@
+import {
+  useEffect,
+  useState,
+  type ChangeEvent,
+  type ReactElement,
+} from 'react';
+
+/**
+ * A single entry in the published `/versions.json` manifest. `base` is the
+ * site sub-path the version is served from (`/` for the latest, `/v0.9/` for
+ * an archived snapshot).
+ */
+interface VersionEntry {
+  label: string;
+  base: string;
+  latest?: boolean;
+}
+
+const RELEASES_URL = 'https://github.com/SebastianWebdev/entangle-ui/releases';
+
+/** Normalize a base path to always have a single leading and trailing slash. */
+const withSlashes = (base: string): string => {
+  let normalized = base;
+  if (!normalized.startsWith('/')) normalized = `/${normalized}`;
+  if (!normalized.endsWith('/')) normalized = `${normalized}/`;
+  return normalized;
+};
+
+export interface VersionSwitcherProps {
+  /** Version label of the build currently being viewed, e.g. `v0.9.0`. */
+  currentLabel: string;
+}
+
+/**
+ * Documentation version selector shown in the site header.
+ *
+ * The list of versions is fetched at runtime from the root `/versions.json`
+ * manifest (written by the deploy workflow), so every archived snapshot —
+ * even ones built before newer versions existed — surfaces the full, current
+ * list. Until at least two versions are published it falls back to a static
+ * badge that still advertises the version this build was made from.
+ */
+export default function VersionSwitcher({
+  currentLabel,
+}: VersionSwitcherProps): ReactElement | null {
+  const [versions, setVersions] = useState<VersionEntry[] | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    fetch('/versions.json')
+      .then(res => (res.ok ? res.json() : null))
+      .then((data: { versions?: VersionEntry[] } | null) => {
+        if (active && data?.versions?.length) setVersions(data.versions);
+      })
+      .catch(() => {
+        /* No manifest (e.g. local preview) — keep the static badge. */
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  // Before a second version exists, a dropdown is pointless — show a badge.
+  if (!versions || versions.length < 2) {
+    return (
+      <a
+        className="version-badge"
+        href={RELEASES_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        title={`Entangle UI ${currentLabel} — view releases on GitHub`}
+      >
+        {currentLabel}
+      </a>
+    );
+  }
+
+  const currentBase = withSlashes(import.meta.env.BASE_URL);
+  const selectedBase =
+    versions.find(v => withSlashes(v.base) === currentBase)?.base ??
+    versions.find(v => v.latest)?.base ??
+    versions[0].base;
+
+  const handleChange = (event: ChangeEvent<HTMLSelectElement>): void => {
+    const targetBase = withSlashes(event.target.value);
+    // Preserve the current page within the target version when possible.
+    const path = window.location.pathname;
+    const subpath = path.startsWith(currentBase)
+      ? path.slice(currentBase.length)
+      : '';
+    window.location.href = targetBase + subpath;
+  };
+
+  return (
+    <select
+      className="version-switcher"
+      value={selectedBase}
+      onChange={handleChange}
+      aria-label="Documentation version"
+    >
+      {versions.map(version => (
+        <option key={version.base} value={version.base}>
+          {version.label}
+          {version.latest ? ' (latest)' : ''}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/docs-site/src/components/overrides/Hero.astro
+++ b/docs-site/src/components/overrides/Hero.astro
@@ -4,6 +4,18 @@ import HeroDecoration from '../demos/HeroDecoration';
 const PAGE_TITLE_ID = '_top';
 const { data } = Astro.locals.starlightRoute.entry;
 const { title = data.title, tagline, actions = [] } = data.hero || {};
+
+// Hero action links live in frontmatter, so the rehype base-prefixer that
+// handles Markdown content doesn't see them. Prefix root-absolute internal
+// links with Astro's base so a versioned snapshot (e.g. /v0.9/) keeps them
+// inside that version instead of jumping back to the site root.
+const baseUrl = import.meta.env.BASE_URL.replace(/\/$/, '');
+const withBase = href => {
+  if (typeof href !== 'string' || !href.startsWith('/') || href.startsWith('//'))
+    return href;
+  if (href === baseUrl || href.startsWith(`${baseUrl}/`)) return href;
+  return baseUrl + href;
+};
 ---
 
 <div class="hero">
@@ -16,7 +28,10 @@ const { title = data.title, tagline, actions = [] } = data.hero || {};
       actions.length > 0 && (
         <div class="sl-flex actions">
           {actions.map(({ icon, link: href, text, variant }) => (
-            <a href={href} class:list={['sl-link-button', variant || 'primary']}>
+            <a
+              href={withBase(href)}
+              class:list={['sl-link-button', variant || 'primary']}
+            >
               {text}
               {icon?.html && <Fragment set:html={icon.html} />}
             </a>

--- a/docs-site/src/components/overrides/SiteTitle.astro
+++ b/docs-site/src/components/overrides/SiteTitle.astro
@@ -1,47 +1,15 @@
 ---
-// Renders Starlight's default site title and appends a version badge so the
-// docs always advertise the package version they were built from. The version
-// is read from the library's root package.json at build time, which the
-// Release workflow has already bumped by the time the docs are deployed.
+// Renders Starlight's default site title plus a documentation version control.
+// The version label is read from the library's root package.json at build time
+// (the Release workflow has already bumped it by the time docs deploy). The
+// VersionSwitcher upgrades the label into a version dropdown once more than one
+// version has been published (driven by the runtime /versions.json manifest).
 import Default from '@astrojs/starlight/components/SiteTitle.astro';
+import VersionSwitcher from '../VersionSwitcher';
 import pkg from '../../../../package.json';
 
-const version = `v${pkg.version}`;
-const releasesHref = 'https://github.com/SebastianWebdev/entangle-ui/releases';
+const currentLabel = `v${pkg.version}`;
 ---
 
 <Default {...Astro.props} />
-
-<a
-  class="version-badge"
-  href={releasesHref}
-  target="_blank"
-  rel="noopener noreferrer"
-  title={`Entangle UI ${version} — view releases on GitHub`}
->
-  {version}
-</a>
-
-<style>
-  .version-badge {
-    align-self: center;
-    flex-shrink: 0;
-    margin-inline-start: 0.5rem;
-    padding: 0.05rem 0.4rem;
-    border: 1px solid var(--sl-color-gray-5);
-    border-radius: 999rem;
-    background: var(--sl-color-gray-6);
-    color: var(--sl-color-gray-2);
-    font-family: var(--sl-font-system-mono);
-    font-size: var(--sl-text-xs);
-    line-height: 1.5;
-    text-decoration: none;
-    white-space: nowrap;
-    transition: color 0.15s ease, border-color 0.15s ease;
-  }
-
-  .version-badge:hover {
-    color: var(--sl-color-text-accent);
-    border-color: var(--sl-color-text-accent);
-  }
-</style>
+<VersionSwitcher currentLabel={currentLabel} client:load />

--- a/docs-site/src/styles/custom.css
+++ b/docs-site/src/styles/custom.css
@@ -60,3 +60,52 @@ nav.sidebar .top-level > li + li {
   background: transparent;
   border-bottom-color: transparent;
 }
+
+/* ─── Documentation version badge / switcher (site header) ─── */
+.version-badge,
+.version-switcher {
+  align-self: center;
+  flex-shrink: 0;
+  margin-inline-start: 0.5rem;
+  border: 1px solid var(--sl-color-gray-5);
+  border-radius: 999rem;
+  background: var(--sl-color-gray-6);
+  color: var(--sl-color-gray-2);
+  font-family: var(--sl-font-system-mono);
+  font-size: var(--sl-text-xs);
+  line-height: 1.5;
+  white-space: nowrap;
+}
+
+.version-badge {
+  padding: 0.05rem 0.4rem;
+  text-decoration: none;
+  transition:
+    color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.version-badge:hover {
+  color: var(--sl-color-text-accent);
+  border-color: var(--sl-color-text-accent);
+}
+
+.version-switcher {
+  padding: 0.1rem 0.4rem;
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+  transition:
+    color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.version-switcher:hover {
+  color: var(--sl-color-white);
+  border-color: var(--sl-color-text-accent);
+}
+
+.version-switcher:focus-visible {
+  outline: 2px solid var(--sl-color-text-accent);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## What

Adds **per-release documentation versioning** with a version switcher, building on the deploy-after-release pipeline from #98.

> ✅ **#98 has merged.** This branch was rebased onto `main`, so the diff is now exactly the versioning change (1 commit, 10 files) — no longer stacked.

## Why this approach (Strategy 2)

The docs render **live library components**. A content-only snapshot (e.g. the `starlight-versions` plugin) would freeze the Markdown but the demos would still import the *latest* library source — so old versions would silently drift/break. Instead, **each release snapshots the actual build**, so every version renders its own components faithfully.

## How it works

Each deploy produces a single GitHub Pages artifact containing:
- the **latest** docs at the site root `/`
- an **immutable snapshot** of this release under `/vMAJOR.MINOR/`

Snapshots are accumulated on a durable `docs-versions` branch (Pages/Actions artifacts expire) and re-assembled on every deploy, so older versions stay live. A runtime `/versions.json` drives the in-header switcher — meaning **older snapshots automatically list newer versions** without rebuilding them.

```
entangle-ui.dev/                  → latest (e.g. v0.10)
entangle-ui.dev/v0.9/...          → frozen 0.9 snapshot
entangle-ui.dev/v0.8/...          → frozen 0.8 snapshot
entangle-ui.dev/versions.json     → manifest consumed by the switcher
```

## Changes

| File | Purpose |
| --- | --- |
| `docs-site/astro.config.mjs` | `base` from `DOCS_BASE` env (unset → root build); set `site` (also silences the sitemap warning) |
| `docs-site/scripts/rehype-base-internal-links.mjs` | Base-prefixes root-absolute Markdown links on versioned builds. Astro prefixes *assets* but not the ~11k internal content/API links, which would otherwise escape a `/vX/` snapshot back to root |
| `docs-site/src/components/overrides/Hero.astro` | Base-prefixes hero action links (they live in frontmatter, not Markdown) |
| `docs-site/src/components/VersionSwitcher.tsx` | Header control; fetches runtime `/versions.json`; falls back to a static version badge until a 2nd version exists. Replaces the previous static badge |
| `docs-site/scripts/generate-versions-json.mjs` | Builds the manifest (newest → `/`, older → `/vX.Y/`); semver-aware sort |
| `.github/workflows/docs.yaml` | Two builds (root + `/vX.Y/`), accumulate on `docs-versions`, assemble, deploy. Now needs `contents: write` |
| `.github/workflows/release.yml` | Grants the docs-deploy caller `contents: write` |

## Verification

- Root build: badge SSRs instantly (`v0.9.0`), links/assets stay root-absolute. ✅
- Versioned `DOCS_BASE=/v0.9` build: **0 escaped internal links** across content **and** the 11k-link API reference; assets + links all `/v0.9/`-prefixed; badge SSR'd. ✅
- Manifest generator unit-tested (semver sort `v0.10 > v0.9`, latest→`/`, empty-dir fallback). ✅
- Assembly step simulated locally (root preserved, snapshots layered, `.git` ignored). ✅
- `npm run lint` / `type-check` / `format` — pass.
- ⚠️ CI-only (not locally testable): the `docs-versions` branch push + Pages deploy. Written defensively (orphan-branch bootstrap, `concurrency` serialization, idempotent commit).

## Notes

- **No repo settings change** — keeps the Pages source as "GitHub Actions".
- First deploy publishes one version (switcher stays a badge); the dropdown appears once a second version ships.
- Slug is **major.minor** (`v0.9`); patches overwrite the same snapshot dir.
- Infra/docs-only → ships with an empty changeset (no package bump).

https://claude.ai/code/session_01E1td2rv6RmFgYGYqfjoBmV

---
_Generated by [Claude Code](https://claude.ai/code/session_01E1td2rv6RmFgYGYqfjoBmV)_