### PR TITLE
fix(docs): emit component CSS globally so client:only demos render styled

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -29,6 +29,9 @@ export default defineConfig({
       components: {
         Hero: './src/components/overrides/Hero.astro',
         SiteTitle: './src/components/overrides/SiteTitle.astro',
+        // Emits the Entangle UI component CSS globally. All demos hydrate with
+        // `client:only`, whose CSS Astro does not collect — see Head.astro.
+        Head: './src/components/overrides/Head.astro',
       },
       social: [
         {

--- a/docs-site/src/components/overrides/Head.astro
+++ b/docs-site/src/components/overrides/Head.astro
@@ -1,0 +1,22 @@
+---
+import Default from '@astrojs/starlight/components/Head.astro';
+
+// Force every Entangle UI stylesheet into the global page CSS.
+//
+// All live demos on the docs site hydrate with `client:only="react"`, and
+// Astro does not collect CSS from client:only islands. The library is styled
+// entirely with zero-runtime vanilla-extract (`*.css.ts`), so without a
+// server-rendered import the component styles are dropped from the production
+// build and every demo renders unstyled — collapsed flex/grid layouts, missing
+// gaps, grid columns stacked into a single column.
+//
+// Eagerly importing the library's stylesheets here fixes that: `@` resolves to
+// the library `src`, and Starlight renders this Head override on every page,
+// server side, so Astro emits the imported CSS as global page CSS regardless of
+// how each demo hydrates. The import is a pure side effect (vanilla-extract
+// `.css.ts` only registers CSS — no runtime, no browser APIs), so it is safe to
+// evaluate during SSR.
+import.meta.glob('@/**/*.css.ts', { eager: true });
+---
+
+<Default />


### PR DESCRIPTION
## Symptom

After the latest changes, the docs site lost all component layout: SplitPane panels stack vertically, Avatar/Badge/Button rows have no gaps, the Icon grid collapses to a single column, Breadcrumbs stack one-per-line, Spacer does nothing — everywhere `Flex`/`Grid`/`Stack`/`SplitPane` are used.

## Root cause

**Astro does not collect CSS from `client:only` islands, and every live demo on the docs site hydrates with `client:only="react"` (543 of them).**

Entangle UI is styled entirely with zero-runtime vanilla-extract (`*.css.ts`). Because the component stylesheets are only ever reachable through `client:only` islands, they were **dropped from the production build entirely** — not just unlinked. The built pages contain **zero** component CSS:

- `display:flex` / `display:grid` → gone (containers fall back to normal flow → SplitPane/Breadcrumbs/grid items stack; inline children like buttons sit next to each other)
- `gap` → gone (no spacing)
- `grid-template-columns: repeat(var(...), 1fr)` → gone (grids collapse to one column)

The **global** theme CSS (`createGlobalTheme` / `globalStyle`) survived because global vanilla-extract CSS is emitted independently of any island — which is exactly why the breakage looked layout-specific rather than total.

This surfaced after the **Astro 5→6 / @astrojs/react 4→5 / Vite 6→7** docs-toolchain upgrade, which changed how island CSS is collected.

### How it was verified
- Built the docs locally; minification-proof selectors (`data-sm-dir`, `data-xs`…`data-xl`, `grid-column:span`) were **0 across the entire `dist/`**, while `--etui-*` theme definitions were present.
- Flipping one demo from `client:only="react"` to `client:visible` (SSR) made **that page's** component CSS reappear — confirming the island-CSS-collection mechanism.

## Fix

Add a Starlight `Head` override that eagerly imports every library stylesheet:

```astro
import.meta.glob('@/**/*.css.ts', { eager: true });
```

Starlight renders `Head` on **every page, server-side**, so Astro emits the imported component CSS as a global page chunk regardless of how each demo hydrates. The import is a pure side effect (vanilla-extract only registers CSS — no runtime, no browser APIs), so it is SSR-safe.

Switching the 543 demos to `client:visible`/`client:load` was rejected: many components (canvas/`window`/`ResizeObserver`-based editor widgets) can't SSR, which is why `client:only` was chosen in the first place.

### Verification after the fix
Rebuilt the docs — the global common chunk now carries the full component CSS (277 `display:flex`, 18 `display:grid`, 32 responsive `data-*-dir` selectors, 65 `grid-column:span` spans, 2251 `--etui-*` usages), the theme contract is unchanged, and `<head>` is intact (single `<title>`, no duplicated tags). Every previously-broken page (Flex, Grid, SplitPane, Spacer, Breadcrumbs, Avatar, Badge, Button, Icon) links it.

## Notes
- Docs-site-only change (1 new file + 1 config line); no library source touched, so no changeset (matches the convention from the #95 docs upgrade).
- Trade-off: component CSS is now shipped globally on the docs site (one shared chunk) instead of per-island — correct and standard for a docs/showcase site, and avoids FOUC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Abhhvq9zqS4UZzWN9csRmS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Abhhvq9zqS4UZzWN9csRmS)_