### PR TITLE
feat: Select fullWidth/onChange contract + PropertyInspector tooltip/checkable/density (C1–D3)

### DIFF
--- a/.changeset/property-panel-fillheight-density.md
+++ b/.changeset/property-panel-fillheight-density.md
@@ -1,0 +1,9 @@
+---
+'entangle-ui': minor
+---
+
+`PropertyPanel`: add fill-height scrolling, row density, and a small control-padding fix.
+
+- **`fillHeight` (new prop).** Fills the parent's height and scrolls the content on overflow without needing a fixed `maxHeight`, reserving a scrollbar gutter so controls don't sit under the overlay scrollbar. Ignored when `maxHeight` is set.
+- **`density` (new prop).** `compact` / `normal` / `spacious` tunes the vertical rhythm (min-height + vertical padding) of all nested `PropertyRow`s via panel context. Default `normal` is unchanged from before.
+- **Control right padding.** `PropertyRow`'s control column right padding was bumped from `xs` (2px) to `sm` (4px) so controls no longer sit flush against the row's right edge. This is a small default visual change.

--- a/.changeset/property-row-tooltip-label.md
+++ b/.changeset/property-row-tooltip-label.md
@@ -1,0 +1,8 @@
+---
+'entangle-ui': minor
+---
+
+`PropertyRow`: fix the label tooltip and allow a `ReactNode` label.
+
+- **Tooltip fix.** The label tooltip never appeared because the tooltip trigger wrapped its content in a `display: contents` element, which generates no box and therefore no hover/focus target (the `Tooltip` primitive disables pointer events on the trigger and re-enables them only on its direct child). The wrapper is now a real `inline-flex` box, so hovering or focusing the label shows the tooltip.
+- **`label: ReactNode`.** `PropertyRow.label` was typed `string` but already rendered any node. It is now typed `React.ReactNode`, so an icon + text (or any custom markup) can be used as a label without a cast. This is a widening, so existing string labels are unaffected.

--- a/.changeset/property-section-checkable.md
+++ b/.changeset/property-section-checkable.md
@@ -1,0 +1,7 @@
+---
+'entangle-ui': minor
+---
+
+`PropertySection`: add a first-class checkable section.
+
+Set `checkable` to render a managed enable/disable toggle in the section header (built on the `Switch` primitive). When the toggle is off, the section body is dimmed and made non-interactive (`pointer-events: none`) but **stays mounted**, so its state is preserved. The toggle is independent of the collapse state and supports controlled and uncontrolled use via `checked` / `defaultChecked` / `onCheckedChange`. The toggle's accessible name defaults to the section `title` and can be overridden with `checkLabel`. All additive — sections without `checkable` are unchanged.

--- a/.changeset/property-section-header-controls.md
+++ b/.changeset/property-section-header-controls.md
@@ -1,0 +1,7 @@
+---
+'entangle-ui': patch
+---
+
+`PropertySection`: render header controls as siblings of the collapse trigger instead of nested inside it.
+
+The enable toggle (`checkable`) and the `actions` slot were rendered inside the section header's trigger `<button>`, which produced invalid HTML (`<button>` cannot contain another `<button>`/interactive control) and a React DOM warning. The header is now a flex strip containing the trigger button and a separate controls group as siblings, so toggles and actions are never nested in a button. The collapse behavior, sizing, and the expanded separator are unchanged; the trigger's hover highlight now covers the trigger area rather than the full strip width.

--- a/.changeset/select-fullwidth-content-dropdown.md
+++ b/.changeset/select-fullwidth-content-dropdown.md
@@ -1,0 +1,8 @@
+---
+'entangle-ui': minor
+---
+
+`Select`: add `fullWidth` and size the open dropdown to its content.
+
+- **`fullWidth` (new prop).** When set, the select stretches the container and trigger to fill the available width instead of shrinking to the selected label. This fixes selects collapsing when placed inside a flex row or property panel. Default `false` preserves the previous content-width behavior.
+- **Content-sized dropdown.** The open dropdown now sizes to its widest option (`width: max-content`), with a minimum of the trigger width (and `minDropdownWidth` when set) and a maximum clamped to the viewport. Long option labels are no longer clipped by a narrow trigger. `minDropdownWidth` continues to act as a floor.

--- a/.changeset/select-onchange-null-contract.md
+++ b/.changeset/select-onchange-null-contract.md
@@ -1,0 +1,12 @@
+---
+'entangle-ui': minor
+---
+
+`Select`: type `onChange` per `clearable` so the value is only nullable when it can actually be cleared.
+
+`SelectProps` is now a discriminated union on `clearable`:
+
+- Without `clearable`, `onChange` is `(value: T) => void` — it never receives `null`, so consumers no longer need a spurious null check.
+- With `clearable`, `onChange` is `(value: T | null) => void` — `null` is emitted by the clear button.
+
+Type-only change (runtime behavior is unchanged). This is stricter than before: an inline `onChange` handler on a non-clearable select now infers `T` instead of `T | null`. Handlers already written to accept `T | null` remain assignable, so most code is unaffected; a handler that explicitly compared the value to `null` on a non-clearable select should drop that dead branch.

--- a/docs-site/src/components/demos/controls/SelectDemo.tsx
+++ b/docs-site/src/components/demos/controls/SelectDemo.tsx
@@ -252,6 +252,47 @@ export function SelectLabels() {
   );
 }
 
+export function SelectFullWidth() {
+  const [value, setValue] = useState<string | null>('react');
+  return (
+    <DemoWrapper withKeyboard>
+      <div style={{ width: '100%', maxWidth: 420 }}>
+        <Select
+          fullWidth
+          label="Framework"
+          options={FRAMEWORKS}
+          value={value}
+          onChange={setValue}
+        />
+      </div>
+    </DemoWrapper>
+  );
+}
+
+const LONG_OPTIONS: SelectOptionItem<string>[] = [
+  { value: 'std', label: 'Standard' },
+  { value: 'pbr', label: 'Physically Based Rendering (Metallic / Roughness)' },
+  { value: 'sss', label: 'Subsurface Scattering — Skin & Translucency' },
+  { value: 'toon', label: 'Toon / Cel Shading' },
+];
+
+export function SelectContentSizedDropdown() {
+  const [value, setValue] = useState<string | null>('std');
+  return (
+    <DemoWrapper withKeyboard>
+      <div style={{ width: 160 }}>
+        <Select
+          label="Shading Model"
+          placeholder="Pick a model..."
+          options={LONG_OPTIONS}
+          value={value}
+          onChange={setValue}
+        />
+      </div>
+    </DemoWrapper>
+  );
+}
+
 export function SelectError() {
   const [material, setMaterial] = useState<string | null>(null);
   return (

--- a/docs-site/src/components/demos/editor/PropertyInspectorDemo.tsx
+++ b/docs-site/src/components/demos/editor/PropertyInspectorDemo.tsx
@@ -86,6 +86,32 @@ export function PropertyRowLabelDemo() {
   );
 }
 
+export function PropertyPanelFillHeightDemo() {
+  const rows = Array.from({ length: 14 }, (_, i) => i);
+
+  return (
+    <DemoWrapper withKeyboard padding="0">
+      <div
+        style={{
+          height: 240,
+          border: '1px solid var(--etui-color-border-default)',
+          borderRadius: 4,
+        }}
+      >
+        <PropertyPanel fillHeight density="compact">
+          <PropertySection title="Channels" defaultExpanded>
+            {rows.map(i => (
+              <PropertyRow key={i} label={`Channel ${i + 1}`}>
+                <NumberInput value={i} onChange={() => {}} />
+              </PropertyRow>
+            ))}
+          </PropertySection>
+        </PropertyPanel>
+      </div>
+    </DemoWrapper>
+  );
+}
+
 export function PropertySectionCheckableDemo() {
   const [fogEnabled, setFogEnabled] = useState(true);
   const [density, setDensity] = useState(0.3);

--- a/docs-site/src/components/demos/editor/PropertyInspectorDemo.tsx
+++ b/docs-site/src/components/demos/editor/PropertyInspectorDemo.tsx
@@ -7,6 +7,7 @@ import {
 } from '@/components/editor/PropertyInspector';
 import { NumberInput } from '@/components/controls';
 import { Checkbox } from '@/components/primitives';
+import { StarIcon } from '@/components/Icons';
 
 export default function PropertyInspectorDemo() {
   const [x, setX] = useState(100);
@@ -30,6 +31,100 @@ export default function PropertyInspectorDemo() {
               <Checkbox
                 checked={visible}
                 onChange={checked => setVisible(checked)}
+              />
+            </PropertyRow>
+          </PropertySection>
+        </PropertyPanel>
+      </div>
+    </DemoWrapper>
+  );
+}
+
+export function PropertyRowLabelDemo() {
+  const [opacity, setOpacity] = useState(0.8);
+  const [roughness, setRoughness] = useState(0.5);
+
+  return (
+    <DemoWrapper withKeyboard padding="0">
+      <div style={{ maxWidth: 350 }}>
+        <PropertyPanel>
+          <PropertySection title="Material" defaultExpanded>
+            <PropertyRow label="Opacity" tooltip="Surface opacity (0–1)">
+              <NumberInput
+                value={opacity}
+                onChange={setOpacity}
+                min={0}
+                max={1}
+                step={0.05}
+              />
+            </PropertyRow>
+            <PropertyRow
+              label={
+                <span
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 4,
+                  }}
+                >
+                  <StarIcon size={12} decorative /> Roughness
+                </span>
+              }
+            >
+              <NumberInput
+                value={roughness}
+                onChange={setRoughness}
+                min={0}
+                max={1}
+                step={0.05}
+              />
+            </PropertyRow>
+          </PropertySection>
+        </PropertyPanel>
+      </div>
+    </DemoWrapper>
+  );
+}
+
+export function PropertySectionCheckableDemo() {
+  const [fogEnabled, setFogEnabled] = useState(true);
+  const [density, setDensity] = useState(0.3);
+  const [bloomEnabled, setBloomEnabled] = useState(false);
+  const [intensity, setIntensity] = useState(1.2);
+
+  return (
+    <DemoWrapper withKeyboard padding="0">
+      <div style={{ maxWidth: 350 }}>
+        <PropertyPanel>
+          <PropertySection
+            title="Fog"
+            checkable
+            checked={fogEnabled}
+            onCheckedChange={setFogEnabled}
+          >
+            <PropertyRow label="Density" tooltip="Volumetric fog density">
+              <NumberInput
+                value={density}
+                onChange={setDensity}
+                min={0}
+                max={1}
+                step={0.01}
+              />
+            </PropertyRow>
+          </PropertySection>
+          <PropertySection
+            title="Bloom"
+            checkable
+            checked={bloomEnabled}
+            onCheckedChange={setBloomEnabled}
+          >
+            <PropertyRow label="Intensity">
+              <NumberInput
+                value={intensity}
+                onChange={setIntensity}
+                min={0}
+                max={5}
+                step={0.1}
               />
             </PropertyRow>
           </PropertySection>

--- a/docs-site/src/content/docs/components/controls/select.mdx
+++ b/docs-site/src/content/docs/components/controls/select.mdx
@@ -15,6 +15,8 @@ import SelectDemo, {
   SelectSizes,
   SelectLabels,
   SelectError,
+  SelectFullWidth,
+  SelectContentSizedDropdown,
 } from '../../../../components/demos/controls/SelectDemo';
 
 Dropdown select component for choosing a single value from a list. Supports searchable filtering, grouped options, keyboard navigation, clearable selection, and multiple visual variants. Built for professional editor interfaces.
@@ -158,6 +160,53 @@ Each option can include an icon rendered before its label.
   ]}
   value={objectType}
   onChange={setObjectType}
+/>
+```
+
+## Full Width
+
+By default the select shrinks to the width of its content, which is convenient
+inside toolbars but means it collapses when placed in a flex row. Set
+`fullWidth` to stretch the trigger to fill its container — ideal for property
+panels and forms.
+
+<ComponentPreview title="Full Width">
+  <SelectFullWidth client:only="react" />
+</ComponentPreview>
+
+```tsx
+<Select
+  fullWidth
+  label="Framework"
+  options={frameworks}
+  value={v}
+  onChange={setV}
+/>
+```
+
+## Content-Sized Dropdown
+
+The open dropdown sizes itself to its widest option (clamped to the viewport),
+so long option labels are never clipped even when the trigger is narrow. Use
+`minDropdownWidth` to set a floor and `fullWidth` to also widen the trigger.
+
+<ComponentPreview title="Content-Sized Dropdown">
+  <SelectContentSizedDropdown client:only="react" />
+</ComponentPreview>
+
+```tsx
+// The trigger is 160px, but the dropdown grows to fit the longest label.
+<Select
+  label="Shading Model"
+  options={[
+    { value: 'std', label: 'Standard' },
+    {
+      value: 'pbr',
+      label: 'Physically Based Rendering (Metallic / Roughness)',
+    },
+  ]}
+  value={model}
+  onChange={setModel}
 />
 ```
 
@@ -343,7 +392,15 @@ Use the `name` prop for native form submission. A hidden `<input>` is rendered w
     {
       name: 'minDropdownWidth',
       type: 'number',
-      description: 'Minimum width of the dropdown in pixels.',
+      description:
+        'Minimum width of the dropdown in pixels. The dropdown still grows past this to fit its content.',
+    },
+    {
+      name: 'fullWidth',
+      type: 'boolean',
+      default: 'false',
+      description:
+        'Whether the select stretches to fill the width of its container.',
     },
     {
       name: 'name',

--- a/docs-site/src/content/docs/components/controls/select.mdx
+++ b/docs-site/src/content/docs/components/controls/select.mdx
@@ -128,6 +128,9 @@ Enable the `searchable` prop to show a filter input inside the dropdown. A custo
 ## Clearable
 
 When `clearable` is enabled, a clear button appears when a value is selected.
+The `onChange` value type follows `clearable`: without it the callback only ever
+receives a real value (`T`), so no null check is needed; with `clearable` it can
+also receive `null` when the selection is cleared.
 
 <ComponentPreview title="Clearable">
   <SelectClearable client:only="react" />
@@ -409,8 +412,9 @@ Use the `name` prop for native form submission. A hidden `<input>` is rendered w
     },
     {
       name: 'onChange',
-      type: '(value: T | null) => void',
-      description: 'Callback when the selected value changes.',
+      type: '(value: T) => void',
+      description:
+        'Callback when the selected value changes. The value type is discriminated by `clearable`: a non-clearable select emits `T`; a `clearable` select emits `T | null` (null comes from the clear button).',
     },
     {
       name: 'onOpenChange',

--- a/docs-site/src/content/docs/components/editor/property-inspector.mdx
+++ b/docs-site/src/content/docs/components/editor/property-inspector.mdx
@@ -5,7 +5,10 @@ description: Property inspector system with collapsible sections, label-value ro
 
 import PropsTable from '../../../../components/PropsTable.astro';
 import ComponentPreview from '../../../../components/ComponentPreview.astro';
-import PropertyInspectorDemo from '../../../../components/demos/editor/PropertyInspectorDemo';
+import PropertyInspectorDemo, {
+  PropertyRowLabelDemo,
+  PropertySectionCheckableDemo,
+} from '../../../../components/demos/editor/PropertyInspectorDemo';
 
 A property inspector system for editor interfaces, modeled after the property panels found in 3D tools (Blender, Unity, Unreal). Composed of four components -- `PropertyPanel`, `PropertySection`, `PropertyRow`, and `PropertyGroup` -- plus a `usePropertyUndo` hook for undo/redo support. The panel provides shared context for size and search filtering to all child components.
 
@@ -112,6 +115,35 @@ Pass a custom element as the `indicator` prop, or `null` to hide the chevron ent
 </PropertySection>
 ```
 
+#### Checkable Section
+
+Set `checkable` to render a managed enable/disable toggle in the header — useful
+for optional effect stacks (fog, bloom, post-processing) where the whole group
+can be switched off. When off, the body is **dimmed and made non-interactive but
+stays mounted**, so its values are preserved. The toggle is independent of the
+collapse state, and supports controlled and uncontrolled use (`checked` /
+`defaultChecked` / `onCheckedChange`). The toggle's accessible name defaults to
+the section `title` (override with `checkLabel`).
+
+<ComponentPreview title="Checkable Section">
+  <PropertySectionCheckableDemo client:only="react" />
+</ComponentPreview>
+
+```tsx
+const [fogEnabled, setFogEnabled] = useState(true);
+
+<PropertySection
+  title="Fog"
+  checkable
+  checked={fogEnabled}
+  onCheckedChange={setFogEnabled}
+>
+  <PropertyRow label="Density">
+    <NumberInput value={density} onChange={setDensity} min={0} max={1} />
+  </PropertyRow>
+</PropertySection>;
+```
+
 ### PropertyRow
 
 A label-value row with configurable split ratio, modified state indicator, tooltip, and reset button. Inherits size from the parent `PropertyPanel` or can override it individually.
@@ -125,6 +157,32 @@ A label-value row with configurable split ratio, modified state indicator, toolt
   onReset={() => setOpacity(1)}
 >
   <Slider value={opacity} onChange={setOpacity} min={0} max={1} />
+</PropertyRow>
+```
+
+#### Label and Tooltip
+
+`label` accepts any `ReactNode`, so a label can pair an icon with text or any
+custom markup. When `tooltip` is set, hovering (or focusing) the label shows a
+tooltip describing the property.
+
+<ComponentPreview title="Label and Tooltip">
+  <PropertyRowLabelDemo client:only="react" />
+</ComponentPreview>
+
+```tsx
+<PropertyRow label="Opacity" tooltip="Surface opacity (0–1)">
+  <NumberInput value={opacity} onChange={setOpacity} min={0} max={1} />
+</PropertyRow>
+
+<PropertyRow
+  label={
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+      <StarIcon size={12} decorative /> Roughness
+    </span>
+  }
+>
+  <NumberInput value={roughness} onChange={setRoughness} min={0} max={1} />
 </PropertyRow>
 ```
 
@@ -360,6 +418,38 @@ function handleChange(newValue: number) {
       description: 'Whether the section is disabled (not collapsible, dimmed).',
     },
     {
+      name: 'checkable',
+      type: 'boolean',
+      default: 'false',
+      description:
+        'Whether to render a managed enable/disable toggle in the header. When off, the body is dimmed and non-interactive but stays mounted.',
+    },
+    {
+      name: 'checked',
+      type: 'boolean',
+      description:
+        'Whether the section is enabled (controlled). Requires checkable.',
+    },
+    {
+      name: 'defaultChecked',
+      type: 'boolean',
+      default: 'true',
+      description:
+        'Whether the section starts enabled (uncontrolled). Requires checkable.',
+    },
+    {
+      name: 'onCheckedChange',
+      type: '(checked: boolean) => void',
+      description:
+        'Callback when the enable toggle changes. Requires checkable.',
+    },
+    {
+      name: 'checkLabel',
+      type: 'string',
+      description:
+        'Accessible label for the enable toggle. Defaults to the section title.',
+    },
+    {
       name: 'size',
       type: "'sm' | 'md' | 'lg'",
       description:
@@ -408,14 +498,15 @@ function handleChange(newValue: number) {
   props={[
     {
       name: 'label',
-      type: 'string',
+      type: 'ReactNode',
       required: true,
-      description: 'Property label text.',
+      description:
+        'Property label. Accepts any renderable node (text, an icon + text, etc.).',
     },
     {
       name: 'tooltip',
       type: 'string',
-      description: 'Tooltip text shown on hover over the label.',
+      description: 'Tooltip text shown when the label is hovered or focused.',
     },
     {
       name: 'children',

--- a/docs-site/src/content/docs/components/editor/property-inspector.mdx
+++ b/docs-site/src/content/docs/components/editor/property-inspector.mdx
@@ -8,6 +8,7 @@ import ComponentPreview from '../../../../components/ComponentPreview.astro';
 import PropertyInspectorDemo, {
   PropertyRowLabelDemo,
   PropertySectionCheckableDemo,
+  PropertyPanelFillHeightDemo,
 } from '../../../../components/demos/editor/PropertyInspectorDemo';
 
 A property inspector system for editor interfaces, modeled after the property panels found in 3D tools (Blender, Unity, Unreal). Composed of four components -- `PropertyPanel`, `PropertySection`, `PropertyRow`, and `PropertyGroup` -- plus a `usePropertyUndo` hook for undo/redo support. The panel provides shared context for size and search filtering to all child components.
@@ -72,6 +73,27 @@ The root container that provides size context and optional search filtering to a
 >
   {/* PropertySection components */}
 </PropertyPanel>
+```
+
+#### Fill Height and Density
+
+For a panel that fills a dock and scrolls when its content overflows, set
+`fillHeight` instead of a fixed `maxHeight`. The panel fills its parent's height
+and reserves a scrollbar gutter so controls never sit under the scrollbar. Use
+`density` (`compact` / `normal` / `spacious`) to tune the vertical rhythm of all
+rows — handy for dense inspectors.
+
+<ComponentPreview title="Fill Height and Density">
+  <PropertyPanelFillHeightDemo client:only="react" />
+</ComponentPreview>
+
+```tsx
+// Fills the 240px-tall parent and scrolls; rows use the compact rhythm.
+<div style={{ height: 240 }}>
+  <PropertyPanel fillHeight density="compact">
+    <PropertySection title="Channels">{/* many rows */}</PropertySection>
+  </PropertyPanel>
+</div>
 ```
 
 ### PropertySection
@@ -321,6 +343,19 @@ function handleChange(newValue: number) {
       type: 'number | string',
       description:
         'Maximum height of the panel. Enables scrolling via ScrollArea when set.',
+    },
+    {
+      name: 'fillHeight',
+      type: 'boolean',
+      default: 'false',
+      description:
+        'Fill the parent height and scroll on overflow (reserves a scrollbar gutter) without a fixed maxHeight. Ignored when maxHeight is set.',
+    },
+    {
+      name: 'density',
+      type: "'compact' | 'normal' | 'spacious'",
+      default: "'normal'",
+      description: 'Vertical spacing density applied to all nested rows.',
     },
     {
       name: 'searchable',

--- a/src/components/controls/Select/Select.css.ts
+++ b/src/components/controls/Select/Select.css.ts
@@ -223,6 +223,11 @@ const selectDropdownIn = keyframes({
 export const dropdownStyle = style({
   position: 'fixed',
   zIndex: vars.zIndex.dropdown,
+  // Size to the widest option (`min-width`/`max-width` are supplied at runtime
+  // from the trigger rect + viewport) so long labels are never clipped by a
+  // narrow trigger.
+  width: 'max-content',
+  boxSizing: 'border-box',
   background: vars.colors.background.elevated,
   border: `1px solid ${vars.colors.border.default}`,
   borderRadius: vars.borderRadius.md,
@@ -269,6 +274,9 @@ export const optionItemRecipe = recipe({
     padding: `${vars.spacing.sm} ${vars.spacing.md}`,
     fontSize: vars.typography.fontSize.md,
     gap: vars.spacing.sm,
+    // Keep each option on a single line so the `max-content` dropdown grows to
+    // the longest label instead of wrapping it.
+    whiteSpace: 'nowrap',
     transition: `background ${vars.transitions.fast}`,
   },
   variants: {

--- a/src/components/controls/Select/Select.test.tsx
+++ b/src/components/controls/Select/Select.test.tsx
@@ -4,7 +4,11 @@ import { vi, beforeEach } from 'vitest';
 import { vars } from '@/theme/contract.css';
 import { renderWithTheme } from '@/tests/testUtils';
 import { Select } from './Select';
-import type { SelectOptionItem, SelectOptionGroup } from './Select.types';
+import type {
+  SelectOptionItem,
+  SelectOptionGroup,
+  SelectProps,
+} from './Select.types';
 
 // Mock ResizeObserver (not available in jsdom, needed by ScrollArea)
 class MockResizeObserver {
@@ -285,6 +289,45 @@ describe('Select', () => {
       expect(
         screen.queryByLabelText('Clear selection')
       ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('onChange typing', () => {
+    // Compile-time contract (C2): `clearable` discriminates the `onChange`
+    // value type. These aliases fail `tsc` if the narrowing ever regresses.
+    type Equal<X, Y> =
+      (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
+        ? true
+        : false;
+    type ParamOf<F> = F extends (value: infer V) => void ? V : never;
+    type NonClearableVariant = Exclude<
+      SelectProps<string>,
+      { clearable: true }
+    >;
+    type ClearableVariant = Extract<SelectProps<string>, { clearable: true }>;
+    type NonClearableValue = ParamOf<
+      NonNullable<NonClearableVariant['onChange']>
+    >;
+    type ClearableValue = ParamOf<NonNullable<ClearableVariant['onChange']>>;
+
+    it('infers a non-null value when not clearable and nullable when clearable', () => {
+      const nonClearableIsT: Equal<NonClearableValue, string> = true;
+      const clearableIsNullable: Equal<ClearableValue, string | null> = true;
+      expect(nonClearableIsT && clearableIsNullable).toBe(true);
+    });
+
+    it('clearable select emits null from the clear button', () => {
+      const handleChange = vi.fn();
+      renderWithTheme(
+        <Select
+          clearable
+          value="normal"
+          options={basicOptions}
+          onChange={handleChange}
+        />
+      );
+      fireEvent.click(screen.getByLabelText('Clear selection'));
+      expect(handleChange).toHaveBeenCalledWith(null);
     });
   });
 

--- a/src/components/controls/Select/Select.test.tsx
+++ b/src/components/controls/Select/Select.test.tsx
@@ -432,4 +432,53 @@ describe('Select', () => {
       expect(screen.getByText('Pick a blend mode')).toBeInTheDocument();
     });
   });
+
+  describe('Full Width', () => {
+    it('stretches the container when fullWidth', () => {
+      renderWithTheme(
+        <Select options={basicOptions} fullWidth testId="fw-select" />
+      );
+      expect(screen.getByTestId('fw-select')).toHaveStyle({ width: '100%' });
+    });
+
+    it('stretches the trigger when fullWidth', () => {
+      renderWithTheme(<Select options={basicOptions} fullWidth />);
+      expect(screen.getByRole('combobox')).toHaveStyle({ width: '100%' });
+    });
+
+    it('does not stretch the container by default', () => {
+      renderWithTheme(
+        <Select options={basicOptions} testId="default-select" />
+      );
+      expect(screen.getByTestId('default-select')).not.toHaveStyle({
+        width: '100%',
+      });
+    });
+  });
+
+  describe('Dropdown Sizing', () => {
+    it('sizes the open dropdown to its content', () => {
+      renderWithTheme(<Select options={basicOptions} />);
+      fireEvent.click(screen.getByRole('combobox'));
+      // `width: max-content` lets the dropdown grow past a narrow trigger so
+      // long option labels are never clipped.
+      expect(screen.getByRole('listbox')).toHaveStyle({
+        width: 'max-content',
+      });
+    });
+
+    it('respects minDropdownWidth as a floor', () => {
+      renderWithTheme(<Select options={basicOptions} minDropdownWidth={300} />);
+      fireEvent.click(screen.getByRole('combobox'));
+      expect(screen.getByRole('listbox')).toHaveStyle({ minWidth: '300px' });
+    });
+
+    it('clamps the dropdown max width to the viewport', () => {
+      renderWithTheme(<Select options={basicOptions} />);
+      fireEvent.click(screen.getByRole('combobox'));
+      // jsdom reports innerWidth 1024 and a zeroed trigger rect, so the max
+      // width is the viewport minus the 8px margin.
+      expect(screen.getByRole('listbox')).toHaveStyle({ maxWidth: '1016px' });
+    });
+  });
 });

--- a/src/components/controls/Select/Select.tsx
+++ b/src/components/controls/Select/Select.tsx
@@ -225,7 +225,10 @@ export function Select<T extends string = string>({
       if (!isControlled) {
         setInternalValue(val);
       }
-      onChange?.(val);
+      // `onChange` is typed per `clearable` (it only receives `null` from the
+      // clear button, which requires `clearable`). Internally we always call it
+      // with `T | null`; the public discriminated union enforces the contract.
+      (onChange as ((value: T | null) => void) | undefined)?.(val);
       close();
     },
     [isControlled, onChange, close]

--- a/src/components/controls/Select/Select.tsx
+++ b/src/components/controls/Select/Select.tsx
@@ -120,6 +120,7 @@ export function Select<T extends string = string>({
   clearable = false,
   maxDropdownHeight = 240,
   minDropdownWidth,
+  fullWidth = false,
   name,
   onChange,
   onOpenChange,
@@ -178,14 +179,21 @@ export function Select<T extends string = string>({
     const openAbove =
       spaceBelow < maxDropdownHeight + 8 && rect.top > spaceBelow;
 
-    const dropdownW =
-      minDropdownWidth !== undefined
-        ? Math.max(rect.width, minDropdownWidth)
-        : rect.width;
+    // The dropdown sizes to its content (`width: max-content` in CSS). Anchor
+    // that growth between a minimum (at least the trigger, and `minDropdownWidth`
+    // when set) and a maximum that keeps it inside the viewport so long option
+    // labels are never clipped by a narrow trigger.
+    const VIEWPORT_MARGIN = 8;
+    const minWidth = Math.max(rect.width, minDropdownWidth ?? 0);
+    const maxWidth = Math.max(
+      minWidth,
+      window.innerWidth - rect.left - VIEWPORT_MARGIN
+    );
 
     setDropdownStyleState({
       left: rect.left,
-      width: dropdownW,
+      minWidth,
+      maxWidth,
       ...(openAbove
         ? {
             bottom: window.innerHeight - rect.top + 4,
@@ -477,7 +485,10 @@ export function Select<T extends string = string>({
   };
 
   return (
-    <div className={cx(selectContainerStyle, className)} style={style}>
+    <div
+      className={cx(selectContainerStyle, className)}
+      style={{ ...(fullWidth ? { width: '100%' } : null), ...style }}
+    >
       {label && (
         <FormLabel
           id={labelId}
@@ -517,6 +528,7 @@ export function Select<T extends string = string>({
           error,
           hasValue: currentValue !== null,
         })}
+        style={fullWidth ? { width: '100%' } : undefined}
         data-testid={testId}
         {...rest}
       >

--- a/src/components/controls/Select/Select.types.ts
+++ b/src/components/controls/Select/Select.types.ts
@@ -139,6 +139,14 @@ export interface SelectBaseProps<T extends string = string> extends Omit<
   minDropdownWidth?: number;
 
   /**
+   * Whether the select stretches to fill the width of its container.
+   * Useful inside flex rows or property panels where the select would
+   * otherwise shrink to the width of its selected label.
+   * @default false
+   */
+  fullWidth?: boolean;
+
+  /**
    * Name attribute for form submission
    */
   name?: string;

--- a/src/components/controls/Select/Select.types.ts
+++ b/src/components/controls/Select/Select.types.ts
@@ -120,12 +120,6 @@ export interface SelectBaseProps<T extends string = string> extends Omit<
   required?: boolean;
 
   /**
-   * Whether a clear button appears when value is selected
-   * @default false
-   */
-  clearable?: boolean;
-
-  /**
    * Maximum height of the dropdown in pixels
    * @default 240
    */
@@ -152,16 +146,51 @@ export interface SelectBaseProps<T extends string = string> extends Omit<
   name?: string;
 
   /**
-   * Change event handler
-   */
-  onChange?: (value: T | null) => void;
-
-  /**
    * Open state change handler
    */
   onOpenChange?: (open: boolean) => void;
 }
 
-export type SelectProps<T extends string = string> = Prettify<
-  SelectBaseProps<T>
->;
+/**
+ * Clearable variant: a clear button is shown, so `onChange` can emit `null`
+ * when the selection is cleared.
+ */
+interface SelectClearableProps<T extends string = string> {
+  /**
+   * Whether a clear button appears when a value is selected.
+   */
+  clearable: true;
+
+  /**
+   * Change event handler. Receives `null` when the selection is cleared.
+   */
+  onChange?: (value: T | null) => void;
+}
+
+/**
+ * Non-clearable variant (default): there is no clear button, so `onChange`
+ * only ever emits a real value — never `null`.
+ */
+interface SelectNonClearableProps<T extends string = string> {
+  /**
+   * Whether a clear button appears when a value is selected.
+   * @default false
+   */
+  clearable?: false;
+
+  /**
+   * Change event handler.
+   */
+  onChange?: (value: T) => void;
+}
+
+/**
+ * Props for the `Select` component.
+ *
+ * `clearable` discriminates the `onChange` contract: a non-clearable select
+ * never emits `null`, so its `onChange` value is `T`; a `clearable` select can
+ * emit `null` from the clear button, so its `onChange` value is `T | null`.
+ */
+export type SelectProps<T extends string = string> =
+  | Prettify<SelectBaseProps<T> & SelectNonClearableProps<T>>
+  | Prettify<SelectBaseProps<T> & SelectClearableProps<T>>;

--- a/src/components/editor/PropertyInspector/PropertyInspector.test.tsx
+++ b/src/components/editor/PropertyInspector/PropertyInspector.test.tsx
@@ -491,6 +491,27 @@ describe('PropertySection', () => {
       const trigger = screen.getByText('Fog').closest('button') as HTMLElement;
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
     });
+
+    it('renders the toggle and actions outside the collapse trigger button', () => {
+      renderWithTheme(
+        <PropertyPanel>
+          <PropertySection
+            title="Fog"
+            checkable
+            actions={<button data-testid="sec-action">A</button>}
+          >
+            <div>Body</div>
+          </PropertySection>
+        </PropertyPanel>
+      );
+      // The interactive header controls must be siblings of the trigger, not
+      // nested inside it (a <button> cannot contain another <button>).
+      const trigger = screen.getByText('Fog').closest('button') as HTMLElement;
+      expect(trigger).not.toContainElement(
+        screen.getByTestId('section-toggle')
+      );
+      expect(trigger).not.toContainElement(screen.getByTestId('sec-action'));
+    });
   });
 
   describe('Accessibility', () => {

--- a/src/components/editor/PropertyInspector/PropertyInspector.test.tsx
+++ b/src/components/editor/PropertyInspector/PropertyInspector.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { screen, fireEvent } from '@testing-library/react';
 import { renderHook, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import { renderWithTheme } from '@/tests/testUtils';
 import { PropertyPanel } from './PropertyPanel';
@@ -317,6 +318,122 @@ describe('PropertySection', () => {
     });
   });
 
+  describe('Checkable', () => {
+    it('renders an enable toggle when checkable', () => {
+      renderWithTheme(
+        <PropertyPanel>
+          <PropertySection title="Fog" checkable>
+            <div>Body</div>
+          </PropertySection>
+        </PropertyPanel>
+      );
+      expect(screen.getByTestId('section-toggle')).toBeInTheDocument();
+      expect(screen.getByRole('switch', { name: 'Fog' })).toBeInTheDocument();
+    });
+
+    it('does not render a toggle when not checkable', () => {
+      renderWithTheme(
+        <PropertyPanel>
+          <PropertySection title="Fog">
+            <div>Body</div>
+          </PropertySection>
+        </PropertyPanel>
+      );
+      expect(screen.queryByTestId('section-toggle')).not.toBeInTheDocument();
+    });
+
+    it('fires onCheckedChange when toggled', () => {
+      const onCheckedChange = vi.fn();
+      renderWithTheme(
+        <PropertyPanel>
+          <PropertySection
+            title="Fog"
+            checkable
+            onCheckedChange={onCheckedChange}
+          >
+            <div>Body</div>
+          </PropertySection>
+        </PropertyPanel>
+      );
+      // Default checked is true, so toggling reports false.
+      fireEvent.click(screen.getByTestId('section-toggle'));
+      expect(onCheckedChange).toHaveBeenCalledWith(false);
+    });
+
+    it('dims but keeps the body mounted when off', () => {
+      renderWithTheme(
+        <PropertyPanel>
+          <PropertySection title="Fog" checkable defaultChecked={false}>
+            <div>Body</div>
+          </PropertySection>
+        </PropertyPanel>
+      );
+      const body = screen.getByText('Body');
+      expect(body).toBeInTheDocument();
+      expect(body.parentElement).toHaveStyle({
+        opacity: '0.5',
+        pointerEvents: 'none',
+      });
+    });
+
+    it('does not dim the body when on', () => {
+      renderWithTheme(
+        <PropertyPanel>
+          <PropertySection title="Fog" checkable defaultChecked>
+            <div>Body</div>
+          </PropertySection>
+        </PropertyPanel>
+      );
+      expect(screen.getByText('Body').parentElement).not.toHaveStyle({
+        opacity: '0.5',
+      });
+    });
+
+    it('respects controlled checked', () => {
+      const { rerender } = renderWithTheme(
+        <PropertyPanel>
+          <PropertySection title="Fog" checkable checked={false}>
+            <div>Body</div>
+          </PropertySection>
+        </PropertyPanel>
+      );
+      expect(screen.getByRole('switch')).toHaveAttribute(
+        'aria-checked',
+        'false'
+      );
+
+      rerender(
+        <PropertyPanel>
+          <PropertySection title="Fog" checkable checked={true}>
+            <div>Body</div>
+          </PropertySection>
+        </PropertyPanel>
+      );
+      expect(screen.getByRole('switch')).toHaveAttribute(
+        'aria-checked',
+        'true'
+      );
+    });
+
+    it('toggling checked does not collapse the section', () => {
+      renderWithTheme(
+        <PropertyPanel>
+          <PropertySection title="Fog" checkable>
+            <div>Body</div>
+          </PropertySection>
+        </PropertyPanel>
+      );
+      expect(screen.getByText('Body')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('section-toggle'));
+
+      // Body stays mounted and the section stays expanded.
+      expect(screen.getByText('Body')).toBeInTheDocument();
+      const trigger = screen.getByText('Fog').closest('button') as HTMLElement;
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    });
+  });
+
   describe('Accessibility', () => {
     it('trigger has aria-expanded', () => {
       renderWithTheme(
@@ -391,6 +508,17 @@ describe('PropertyRow', () => {
       );
       expect(screen.getByText('Position')).toBeInTheDocument();
       expect(screen.getByText('0, 0, 0')).toBeInTheDocument();
+    });
+
+    it('renders a ReactNode label', () => {
+      renderWithTheme(
+        <PropertyPanel>
+          <PropertyRow label={<em data-testid="node-label">Position</em>}>
+            <span>0, 0, 0</span>
+          </PropertyRow>
+        </PropertyPanel>
+      );
+      expect(screen.getByTestId('node-label')).toBeInTheDocument();
     });
 
     it('renders modified dot when modified', () => {
@@ -468,6 +596,38 @@ describe('PropertyRow', () => {
 
       fireEvent.click(screen.getByTestId('reset-button'));
       expect(onReset).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Label tooltip', () => {
+    it('gives the tooltip a real hover target (not display: contents)', () => {
+      renderWithTheme(
+        <PropertyPanel>
+          <PropertyRow label="Opacity" tooltip="Object opacity (0-1)">
+            <span>Value</span>
+          </PropertyRow>
+        </PropertyPanel>
+      );
+      // Regression guard: the previous wrapper used `display: contents`, which
+      // generated no box, so the tooltip never had a hover target.
+      const wrapper = screen.getByText('Opacity').parentElement as HTMLElement;
+      expect(wrapper).not.toHaveStyle({ display: 'contents' });
+    });
+
+    it('shows the tooltip when the label is hovered', async () => {
+      const user = userEvent.setup();
+      renderWithTheme(
+        <PropertyPanel>
+          <PropertyRow label="Opacity" tooltip="Object opacity (0-1)">
+            <span>Value</span>
+          </PropertyRow>
+        </PropertyPanel>
+      );
+
+      await user.hover(screen.getByText('Opacity'));
+      expect(
+        await screen.findByText('Object opacity (0-1)', {}, { timeout: 2000 })
+      ).toBeInTheDocument();
     });
   });
 });

--- a/src/components/editor/PropertyInspector/PropertyInspector.test.tsx
+++ b/src/components/editor/PropertyInspector/PropertyInspector.test.tsx
@@ -106,6 +106,65 @@ describe('PropertyPanel', () => {
       expect(screen.getByPlaceholderText('Filter...')).toBeInTheDocument();
     });
   });
+
+  describe('Fill height', () => {
+    it('wraps content in a scroll area when fillHeight (no maxHeight)', () => {
+      const { container } = renderWithTheme(<TestPanel fillHeight />);
+      expect(
+        container.querySelector('[id^="scrollarea-"]')
+      ).toBeInTheDocument();
+    });
+
+    it('does not wrap content in a scroll area by default', () => {
+      const { container } = renderWithTheme(<TestPanel />);
+      expect(
+        container.querySelector('[id^="scrollarea-"]')
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Density', () => {
+    it('applies compact density to rows', () => {
+      renderWithTheme(
+        <PropertyPanel density="compact">
+          <PropertyRow label="X" testId="density-row">
+            <span>v</span>
+          </PropertyRow>
+        </PropertyPanel>
+      );
+      // md base (26px) - compact delta (4px)
+      expect(screen.getByTestId('density-row')).toHaveStyle({
+        minHeight: '22px',
+      });
+    });
+
+    it('applies spacious density to rows', () => {
+      renderWithTheme(
+        <PropertyPanel density="spacious">
+          <PropertyRow label="X" testId="density-row">
+            <span>v</span>
+          </PropertyRow>
+        </PropertyPanel>
+      );
+      // md base (26px) + spacious delta (6px)
+      expect(screen.getByTestId('density-row')).toHaveStyle({
+        minHeight: '32px',
+      });
+    });
+
+    it('defaults to normal density', () => {
+      renderWithTheme(
+        <PropertyPanel>
+          <PropertyRow label="X" testId="density-row">
+            <span>v</span>
+          </PropertyRow>
+        </PropertyPanel>
+      );
+      expect(screen.getByTestId('density-row')).toHaveStyle({
+        minHeight: '26px',
+      });
+    });
+  });
 });
 
 // === PropertySection ===

--- a/src/components/editor/PropertyInspector/PropertyInspector.types.ts
+++ b/src/components/editor/PropertyInspector/PropertyInspector.types.ts
@@ -134,6 +134,37 @@ export interface PropertySectionBaseProps extends Omit<
   disabled?: boolean;
 
   /**
+   * Whether this section renders a managed enable/disable toggle in its header.
+   * When the toggle is off, the section body is dimmed and made
+   * non-interactive (but stays mounted). The toggle is independent of the
+   * collapse state.
+   * @default false
+   */
+  checkable?: boolean;
+
+  /**
+   * Whether the section is enabled (controlled). Requires `checkable`.
+   */
+  checked?: boolean;
+
+  /**
+   * Whether the section starts enabled (uncontrolled). Requires `checkable`.
+   * @default true
+   */
+  defaultChecked?: boolean;
+
+  /**
+   * Callback when the enable toggle changes. Requires `checkable`.
+   */
+  onCheckedChange?: (checked: boolean) => void;
+
+  /**
+   * Accessible label for the enable toggle.
+   * @default the section `title`
+   */
+  checkLabel?: string;
+
+  /**
    * Size override for this section and its rows
    */
   size?: PropertyInspectorSize;
@@ -161,9 +192,9 @@ export type PropertySectionProps = Prettify<PropertySectionBaseProps>;
 
 export interface PropertyRowBaseProps extends BaseComponent {
   /**
-   * Property label text
+   * Property label. Accepts any renderable node (text, an icon + text, etc.).
    */
-  label: string;
+  label: React.ReactNode;
 
   /**
    * Tooltip text for the label (shown on hover)

--- a/src/components/editor/PropertyInspector/PropertyInspector.types.ts
+++ b/src/components/editor/PropertyInspector/PropertyInspector.types.ts
@@ -6,6 +6,14 @@ import type React from 'react';
 
 export type PropertyInspectorSize = Size;
 
+/**
+ * Vertical spacing density applied to property rows.
+ * - `compact`: tighter rows for dense inspectors
+ * - `normal`: default spacing
+ * - `spacious`: roomier rows
+ */
+export type PropertyDensity = 'compact' | 'normal' | 'spacious';
+
 // --- PropertyPanel ---
 
 export interface PropertyPanelBaseProps extends BaseComponent {
@@ -36,6 +44,21 @@ export interface PropertyPanelBaseProps extends BaseComponent {
    * @default "100%"
    */
   maxHeight?: number | string;
+
+  /**
+   * Fill the available height of the parent and scroll the content when it
+   * overflows, without needing a fixed `maxHeight`. A scrollbar gutter is
+   * reserved so controls never sit under the scrollbar. Ignored when
+   * `maxHeight` is set.
+   * @default false
+   */
+  fillHeight?: boolean;
+
+  /**
+   * Vertical spacing density applied to all nested rows.
+   * @default "normal"
+   */
+  density?: PropertyDensity;
 
   /**
    * Whether to show a search/filter input in the header
@@ -295,6 +318,7 @@ export type PropertyGroupProps = Prettify<PropertyGroupBaseProps>;
 
 export interface PropertyPanelContextValue {
   size: PropertyInspectorSize;
+  density: PropertyDensity;
   searchQuery: string;
 }
 

--- a/src/components/editor/PropertyInspector/PropertyPanel.css.ts
+++ b/src/components/editor/PropertyInspector/PropertyPanel.css.ts
@@ -53,6 +53,12 @@ export const panelContent = style({
   boxSizing: 'border-box',
 });
 
+// In fill-height scroll mode the overlay scrollbar sits over the right edge, so
+// reserve a gutter to keep controls clear of it.
+export const panelContentScroll = style({
+  paddingRight: vars.spacing.lg,
+});
+
 export const panelFooter = style({
   flexShrink: 0,
   borderTop: `1px solid ${vars.colors.border.default}`,

--- a/src/components/editor/PropertyInspector/PropertyPanel.tsx
+++ b/src/components/editor/PropertyInspector/PropertyPanel.tsx
@@ -19,6 +19,7 @@ import {
   searchWrapper,
   searchInputBase,
   panelContent,
+  panelContentScroll,
   panelFooter,
   contentTopSpacingVar,
   contentBottomSpacingVar,
@@ -79,6 +80,8 @@ export const PropertyPanel: React.FC<PropertyPanelProps> = ({
   footer,
   size = 'md',
   maxHeight,
+  fillHeight = false,
+  density = 'normal',
   searchable = false,
   searchPlaceholder = 'Search properties...',
   onSearchChange,
@@ -110,9 +113,10 @@ export const PropertyPanel: React.FC<PropertyPanelProps> = ({
   const contextValue = useMemo<PropertyPanelContextValue>(
     () => ({
       size,
+      density,
       searchQuery: deferredSearchQuery.toLowerCase(),
     }),
-    [size, deferredSearchQuery]
+    [size, density, deferredSearchQuery]
   );
 
   const hasHeader = header != null || searchable;
@@ -180,6 +184,20 @@ export const PropertyPanel: React.FC<PropertyPanelProps> = ({
             fadeMask
           >
             {content}
+          </ScrollArea>
+        ) : fillHeight ? (
+          <ScrollArea
+            direction="vertical"
+            scrollbarVisibility="auto"
+            fadeMask
+            style={{ flex: 1, minHeight: 0 }}
+          >
+            <div
+              className={cx(panelContent, panelContentScroll)}
+              style={contentStyle}
+            >
+              {children}
+            </div>
           </ScrollArea>
         ) : (
           content

--- a/src/components/editor/PropertyInspector/PropertyRow.css.ts
+++ b/src/components/editor/PropertyInspector/PropertyRow.css.ts
@@ -44,6 +44,18 @@ export const fullWidthLabel = style({
   userSelect: 'none',
 });
 
+// Wrapper for the tooltip trigger. It must generate a real box (not
+// `display: contents`) so the Tooltip has a hover/focus target — the Tooltip
+// primitive disables pointer events on the trigger itself and re-enables them
+// only on its direct child.
+export const labelTooltipTarget = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  minWidth: 0,
+  maxWidth: '100%',
+  overflow: 'hidden',
+});
+
 export const modifiedDot = style({
   width: '4px',
   height: '4px',

--- a/src/components/editor/PropertyInspector/PropertyRow.css.ts
+++ b/src/components/editor/PropertyInspector/PropertyRow.css.ts
@@ -9,7 +9,8 @@ export const controlRatioVar = createVar();
 
 export const rowRoot = style({
   position: 'relative',
-  padding: '2px 8px',
+  // Horizontal padding only — vertical padding is applied inline per density.
+  padding: `0 ${vars.spacing.md}`,
   transition: `background ${vars.transitions.fast}`,
   selectors: {
     '&:hover': {
@@ -71,7 +72,8 @@ export const rowControl = style({
   display: 'flex',
   alignItems: 'center',
   minWidth: 0,
-  paddingRight: vars.spacing.xs,
+  // Keep the control clear of the row's right edge / scrollbar gutter.
+  paddingRight: vars.spacing.sm,
 });
 
 export const fullWidthControl = style({
@@ -80,7 +82,7 @@ export const fullWidthControl = style({
   width: '100%',
   flex: '1 1 auto',
   minWidth: 0,
-  paddingRight: vars.spacing.xs,
+  paddingRight: vars.spacing.sm,
 });
 
 export const resetButton = style({

--- a/src/components/editor/PropertyInspector/PropertyRow.tsx
+++ b/src/components/editor/PropertyInspector/PropertyRow.tsx
@@ -23,6 +23,7 @@ import {
 } from './PropertyRow.css';
 
 import type {
+  PropertyDensity,
   PropertyInspectorSize,
   PropertyRowProps,
 } from './PropertyInspector.types';
@@ -53,6 +54,21 @@ const ROW_SIZE_MAP: Record<PropertyInspectorSize, RowSizeConfig> = {
   },
 };
 
+// --- Density maps ---
+
+interface DensityConfig {
+  /** Adjustment applied to the size-based min-height (px). */
+  minHeightDelta: number;
+  /** Vertical padding above/below the row content (px). */
+  paddingBlock: number;
+}
+
+const DENSITY_MAP: Record<PropertyDensity, DensityConfig> = {
+  compact: { minHeightDelta: -4, paddingBlock: 0 },
+  normal: { minHeightDelta: 0, paddingBlock: 2 },
+  spacious: { minHeightDelta: 6, paddingBlock: 5 },
+};
+
 // --- Component ---
 
 export const PropertyRow: React.FC<PropertyRowProps> = ({
@@ -78,6 +94,8 @@ export const PropertyRow: React.FC<PropertyRowProps> = ({
   const panelCtx = usePropertyPanelContext();
   const size = sizeProp ?? panelCtx?.size ?? 'md';
   const sizeConfig = ROW_SIZE_MAP[size];
+  const densityConfig = DENSITY_MAP[panelCtx?.density ?? 'normal'];
+  const rowMinHeight = sizeConfig.minHeight + densityConfig.minHeightDelta;
 
   const handleResetClick = useCallback(
     (e: React.MouseEvent) => {
@@ -126,7 +144,9 @@ export const PropertyRow: React.FC<PropertyRowProps> = ({
         display: visible ? 'flex' : 'none',
         flexDirection: fullWidth ? 'column' : 'row',
         alignItems: fullWidth ? 'stretch' : 'center',
-        minHeight: `${sizeConfig.minHeight}px`,
+        minHeight: `${rowMinHeight}px`,
+        paddingTop: `${densityConfig.paddingBlock}px`,
+        paddingBottom: `${densityConfig.paddingBlock}px`,
         opacity: disabled ? 0.5 : 1,
         pointerEvents: disabled ? 'none' : 'auto',
       }}

--- a/src/components/editor/PropertyInspector/PropertyRow.tsx
+++ b/src/components/editor/PropertyInspector/PropertyRow.tsx
@@ -15,6 +15,7 @@ import {
   rowRoot,
   rowLabel,
   fullWidthLabel,
+  labelTooltipTarget,
   modifiedDot,
   rowControl,
   fullWidthControl,
@@ -98,7 +99,7 @@ export const PropertyRow: React.FC<PropertyRowProps> = ({
 
   const labelElement = tooltip ? (
     <Tooltip title={tooltip}>
-      <span style={{ display: 'contents' }}>
+      <span className={labelTooltipTarget}>
         {modifiedDotEl}
         {labelText}
       </span>

--- a/src/components/editor/PropertyInspector/PropertySection.css.ts
+++ b/src/components/editor/PropertyInspector/PropertySection.css.ts
@@ -16,6 +16,42 @@ globalStyle(`${sectionRoot} + ${sectionRoot}`, {
   marginTop: vars.spacing.sm,
 });
 
+// The header strip carries the background, height, and the expanded separator.
+// Interactive controls (the trigger button, the enable toggle, and `actions`)
+// are siblings inside it — so the toggle/actions are never nested in a button.
+export const sectionHeader = recipe({
+  base: {
+    display: 'flex',
+    alignItems: 'stretch',
+    width: '100%',
+    background: vars.colors.surface.default,
+  },
+  variants: {
+    size: {
+      sm: { height: '24px' },
+      md: { height: '28px' },
+      lg: { height: '32px' },
+    },
+    disabled: {
+      true: { opacity: 0.5 },
+      false: { opacity: 1 },
+    },
+    expanded: {
+      true: {
+        borderBottom: `1px solid ${vars.colors.border.default}`,
+      },
+      false: {
+        borderBottom: 'none',
+      },
+    },
+  },
+  defaultVariants: {
+    size: 'md',
+    disabled: false,
+    expanded: false,
+  },
+});
+
 export const sectionTrigger = recipe({
   base: {
     margin: 0,
@@ -23,13 +59,14 @@ export const sectionTrigger = recipe({
     fontFamily: 'inherit',
     outline: 'none',
     userSelect: 'none',
-    width: '100%',
+    flex: 1,
+    minWidth: 0,
     textAlign: 'left',
     display: 'flex',
     alignItems: 'center',
     gap: vars.spacing.sm,
     fontWeight: vars.typography.fontWeight.medium,
-    background: vars.colors.surface.default,
+    background: 'transparent',
     color: vars.colors.text.primary,
     transition: `background ${vars.transitions.fast}`,
     selectors: {
@@ -45,17 +82,14 @@ export const sectionTrigger = recipe({
   variants: {
     size: {
       sm: {
-        height: '24px',
         padding: `0 ${vars.spacing.sm}`,
         fontSize: vars.typography.fontSize.md,
       },
       md: {
-        height: '28px',
         padding: `0 ${vars.spacing.md}`,
         fontSize: vars.typography.fontSize.md,
       },
       lg: {
-        height: '32px',
         padding: `0 ${vars.spacing.lg}`,
         fontSize: vars.typography.fontSize.lg,
       },
@@ -63,26 +97,15 @@ export const sectionTrigger = recipe({
     disabled: {
       true: {
         cursor: 'not-allowed',
-        opacity: 0.5,
       },
       false: {
         cursor: 'pointer',
-        opacity: 1,
-      },
-    },
-    expanded: {
-      true: {
-        borderBottom: `1px solid ${vars.colors.border.default}`,
-      },
-      false: {
-        borderBottom: 'none',
       },
     },
   },
   defaultVariants: {
     size: 'md',
     disabled: false,
-    expanded: false,
   },
 });
 
@@ -118,11 +141,12 @@ export const sectionLabel = style({
   whiteSpace: 'nowrap',
 });
 
-export const actionsArea = style({
+export const headerControls = style({
   display: 'flex',
   alignItems: 'center',
-  marginLeft: 'auto',
+  flexShrink: 0,
   gap: vars.spacing.xs,
+  paddingRight: vars.spacing.md,
 });
 
 export const contentWrapper = recipe({

--- a/src/components/editor/PropertyInspector/PropertySection.tsx
+++ b/src/components/editor/PropertyInspector/PropertySection.tsx
@@ -9,12 +9,13 @@ import { cx } from '@/utils/cx';
 import { usePropertyPanelContext } from './PropertyPanel';
 import {
   sectionRoot,
+  sectionHeader,
   sectionTrigger,
   chevron,
   chevronExpanded,
   iconArea,
   sectionLabel,
-  actionsArea,
+  headerControls,
   contentWrapper,
   contentInner,
 } from './PropertySection.css';
@@ -107,18 +108,6 @@ export const PropertySection: React.FC<PropertySectionProps> = ({
   // non-interactive but stays mounted (so its state is preserved).
   const isBodyDisabled = checkable && !resolvedChecked;
 
-  const handleActionsClick = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation();
-  }, []);
-
-  // Prevent keyboard activation on nested action controls from bubbling up
-  // and toggling the section trigger.
-  const handleActionsKeyDown = useCallback((e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.stopPropagation();
-    }
-  }, []);
-
   const showIndicator = indicator !== null;
 
   return (
@@ -129,46 +118,42 @@ export const PropertySection: React.FC<PropertySectionProps> = ({
       data-testid={testId}
       {...rest}
     >
-      <button
-        type="button"
-        id={triggerId}
-        aria-expanded={resolvedExpanded}
-        aria-controls={contentId}
-        aria-disabled={disabled || undefined}
-        disabled={disabled}
-        onClick={handleToggle}
-        onContextMenu={onContextMenu}
-        className={sectionTrigger({
+      <div
+        className={sectionHeader({
           size,
           disabled,
           expanded: resolvedExpanded,
         })}
       >
-        {showIndicator && (
-          <span
-            className={cx(chevron, resolvedExpanded && chevronExpanded)}
-            style={{
-              width: `${sizeConfig.chevronSize}px`,
-              height: `${sizeConfig.chevronSize}px`,
-            }}
-          >
-            {indicator ?? (
-              <ChevronRightIcon size={sizeConfig.chevronSize} decorative />
-            )}
-          </span>
-        )}
-        {icon && <span className={iconArea}>{icon}</span>}
-        <span className={sectionLabel}>{title}</span>
+        <button
+          type="button"
+          id={triggerId}
+          aria-expanded={resolvedExpanded}
+          aria-controls={contentId}
+          aria-disabled={disabled || undefined}
+          disabled={disabled}
+          onClick={handleToggle}
+          onContextMenu={onContextMenu}
+          className={sectionTrigger({ size, disabled })}
+        >
+          {showIndicator && (
+            <span
+              className={cx(chevron, resolvedExpanded && chevronExpanded)}
+              style={{
+                width: `${sizeConfig.chevronSize}px`,
+                height: `${sizeConfig.chevronSize}px`,
+              }}
+            >
+              {indicator ?? (
+                <ChevronRightIcon size={sizeConfig.chevronSize} decorative />
+              )}
+            </span>
+          )}
+          {icon && <span className={iconArea}>{icon}</span>}
+          <span className={sectionLabel}>{title}</span>
+        </button>
         {(checkable || actions) && (
-          // This wrapper is a non-semantic propagation boundary for the
-          // enable toggle and user-supplied action controls it hosts; it is
-          // not itself interactive, so it intentionally has no role.
-          // eslint-disable-next-line jsx-a11y/no-static-element-interactions
-          <span
-            className={actionsArea}
-            onClick={handleActionsClick}
-            onKeyDown={handleActionsKeyDown}
-          >
+          <span className={headerControls}>
             {checkable && (
               <Switch
                 size={size}
@@ -182,7 +167,7 @@ export const PropertySection: React.FC<PropertySectionProps> = ({
             {actions}
           </span>
         )}
-      </button>
+      </div>
 
       {(resolvedExpanded || keepMounted) && (
         <div

--- a/src/components/editor/PropertyInspector/PropertySection.tsx
+++ b/src/components/editor/PropertyInspector/PropertySection.tsx
@@ -3,6 +3,7 @@
 import React, { useCallback, useId, useState } from 'react';
 
 import { ChevronRightIcon } from '@/components/Icons';
+import { Switch } from '@/components/primitives/Switch';
 import { cx } from '@/utils/cx';
 
 import { usePropertyPanelContext } from './PropertyPanel';
@@ -46,6 +47,11 @@ export const PropertySection: React.FC<PropertySectionProps> = ({
   onExpandedChange,
   keepMounted = false,
   disabled = false,
+  checkable = false,
+  checked: checkedProp,
+  defaultChecked = true,
+  onCheckedChange,
+  checkLabel,
   size: sizeProp,
   indicator,
   onContextMenu,
@@ -69,6 +75,12 @@ export const PropertySection: React.FC<PropertySectionProps> = ({
   const isControlled = expandedProp !== undefined;
   const resolvedExpanded = isControlled ? expandedProp : internalExpanded;
 
+  // Enable/disable toggle state (controlled or uncontrolled), mirroring the
+  // expanded-state bridge above. Independent of the collapse state.
+  const [internalChecked, setInternalChecked] = useState(defaultChecked);
+  const isCheckedControlled = checkedProp !== undefined;
+  const resolvedChecked = isCheckedControlled ? checkedProp : internalChecked;
+
   const handleToggle = useCallback(() => {
     if (disabled) return;
 
@@ -80,6 +92,20 @@ export const PropertySection: React.FC<PropertySectionProps> = ({
 
     onExpandedChange?.(nextExpanded);
   }, [disabled, resolvedExpanded, isControlled, onExpandedChange]);
+
+  const handleCheckedChange = useCallback(
+    (next: boolean) => {
+      if (!isCheckedControlled) {
+        setInternalChecked(next);
+      }
+      onCheckedChange?.(next);
+    },
+    [isCheckedControlled, onCheckedChange]
+  );
+
+  // When the section is checkable and switched off, the body is dimmed and made
+  // non-interactive but stays mounted (so its state is preserved).
+  const isBodyDisabled = checkable && !resolvedChecked;
 
   const handleActionsClick = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
@@ -133,16 +159,26 @@ export const PropertySection: React.FC<PropertySectionProps> = ({
         )}
         {icon && <span className={iconArea}>{icon}</span>}
         <span className={sectionLabel}>{title}</span>
-        {actions && (
+        {(checkable || actions) && (
           // This wrapper is a non-semantic propagation boundary for the
-          // user-supplied action controls it hosts; it is not itself
-          // interactive, so it intentionally has no role.
+          // enable toggle and user-supplied action controls it hosts; it is
+          // not itself interactive, so it intentionally has no role.
           // eslint-disable-next-line jsx-a11y/no-static-element-interactions
           <span
             className={actionsArea}
             onClick={handleActionsClick}
             onKeyDown={handleActionsKeyDown}
           >
+            {checkable && (
+              <Switch
+                size={size}
+                checked={resolvedChecked}
+                onChange={handleCheckedChange}
+                disabled={disabled}
+                aria-label={checkLabel ?? title}
+                testId="section-toggle"
+              />
+            )}
             {actions}
           </span>
         )}
@@ -156,7 +192,17 @@ export const PropertySection: React.FC<PropertySectionProps> = ({
           aria-labelledby={triggerId}
           hidden={!resolvedExpanded || undefined}
         >
-          <div className={contentInner}>{children}</div>
+          <div
+            className={contentInner}
+            style={
+              isBodyDisabled
+                ? { opacity: 0.5, pointerEvents: 'none' }
+                : undefined
+            }
+            aria-disabled={isBodyDisabled || undefined}
+          >
+            {children}
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
Implements tasks **C1–D3** from `docs/plans/2026-06-23-feedback-remediation.md` — the **Select** (C) and **PropertyInspector** (D) workstreams. Each task is a focused commit with its own changeset.

## Workstream C — Select

### C1 — `fullWidth` + content-sized dropdown 🟠 (`970abb9`)
- New `fullWidth` prop stretches the container **and** trigger to fill their container instead of shrinking to the selected label (fixes collapse inside flex rows / property panels). Default `false` keeps current behavior.
- The open dropdown now sizes to its **widest option** (`width: max-content`), floored at the trigger width / `minDropdownWidth` and clamped to the viewport, so long labels are never clipped by a narrow trigger. `minDropdownWidth` still acts as a floor.

### C2 — `onChange` null-contract typing 🟡 (`cce2016`)
- `SelectProps` is now a **discriminated union on `clearable`**: non-clearable `onChange` is `(value: T) => void` (never null); `clearable` `onChange` is `(value: T | null) => void`.
- Type-only change (runtime unchanged). A `tsc`-enforced type-level test pins the contract. Existing handlers that accept `T | null` remain assignable, so internal usages (`TransformControl`, `CurveToolbar`) are unaffected.

## Workstream D — PropertyInspector

### D1 — `PropertyRow` tooltip fix + `label: ReactNode` 🟠 (`ae21396`)
- **Tooltip fix:** the label tooltip never showed because its trigger wrapper used `display: contents` (no box → no hover/focus target; the `Tooltip` primitive disables pointer events on the trigger and re-enables them only on its direct child). The wrapper is now a real `inline-flex` box.
- `label` widened from `string` to `React.ReactNode` (additive widening).

### D2 — `PropertySection` checkable section 🟡 (`ae21396`)
- New `checkable` with `checked` / `defaultChecked` / `onCheckedChange` / `checkLabel`. Renders a managed `Switch` in the header that **dims (but keeps mounted)** the body when off. Independent of the collapse state; controlled + uncontrolled. The toggle's accessible name defaults to `title` (no new hard-coded strings).

### D3 — `PropertyPanel` fill-height scroll + density + spacing 🟠 (`6b49c20`)
- New `fillHeight`: fills the parent height and scrolls on overflow without a fixed `maxHeight`, reserving a scrollbar gutter.
- New `density` (`compact` / `normal` / `spacious`) threaded through panel context to tune `PropertyRow` vertical rhythm. `normal` is unchanged from before.
- Bumped `PropertyRow` control-column right padding `xs` → `sm` so controls no longer sit flush against the row edge (**small default visual change**, called out in the changeset).

## Verification (Definition of Done)
- `npm run lint` ✅
- `npm run type-check` ✅
- `npm test` ✅ — **3159 passed**, 2 pre-existing skips, 151 files (no cross-component regressions)
- `npm run format:check` ✅
- 5 changesets added (one per task); docs pages + demos updated for every new public API.

> Note: the docs-site (Astro) build was not run locally (its deps aren't installed in this environment), but demo export/import names were verified to match and the demos use only the validated APIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VuTB3waHLzNWsEQFDAHRQK

---
_Generated by [Claude Code](https://claude.ai/code/session_01VuTB3waHLzNWsEQFDAHRQK)_