### PR TITLE
feat: feedback remediation E1–G3 (shell chrome, MenuBar checkable, overlay z-index, slider/spinner/iconbutton polish)

### DIFF
--- a/.changeset/etui-appshell-menubar-chrome.md
+++ b/.changeset/etui-appshell-menubar-chrome.md
@@ -1,0 +1,11 @@
+---
+'entangle-ui': minor
+---
+
+**E1 — AppShell top-chrome + MenuBar fill/inset.** `AppShell.MenuBar` now paints
+the menu-bar chrome background (`--etui-shell-menubar-bg`) on the slot, and
+`MenuBar` stretches to fill its host slot so the top chrome reads as one
+continuous strip instead of a lighter content-width block. MenuBar triggers now
+inset their hover/active fill (rounded, vertically centered) from the chrome
+edges. Docs clarify that side toolbar slots (`AppShell.Toolbar position="left|right"`)
+are the intended home for docked panels. Visual default change — no API change.

--- a/.changeset/etui-iconbutton-icon-prop.md
+++ b/.changeset/etui-iconbutton-icon-prop.md
@@ -1,0 +1,8 @@
+---
+'entangle-ui': minor
+---
+
+**G1 — Align `Button` / `IconButton` icon API.** `IconButton` now accepts an
+optional `icon` prop mirroring `Button`'s `icon`, so `<IconButton icon={…} />`
+type-checks and the two components share one API. `children` still works for
+back-compat (now optional); when both are set, `icon` wins. Additive.

--- a/.changeset/etui-menubar-checkable.md
+++ b/.changeset/etui-menubar-checkable.md
@@ -1,0 +1,11 @@
+---
+'entangle-ui': minor
+---
+
+**E2 — MenuBar checkable / radio items.** Add `MenuBar.CheckboxItem`
+(`checked` / `defaultChecked` / `onCheckedChange`) and `MenuBar.RadioGroup` +
+`MenuBar.RadioItem` (`value` / `defaultValue` / `onValueChange`), mirroring the
+navigation `Menu` API. Items reserve a leading check-mark gutter so checked and
+unchecked rows align, use `role="menuitemcheckbox"` / `role="menuitemradio"` with
+`aria-checked`, participate in arrow-key navigation, and keep the menu open on
+activation by default (`closeOnClick={false}`). Additive.

--- a/.changeset/etui-slider-tooltip-portal.md
+++ b/.changeset/etui-slider-tooltip-portal.md
@@ -1,0 +1,11 @@
+---
+'entangle-ui': minor
+---
+
+**F1 — Slider value tooltip → portal.** The drag value tooltip was an
+absolutely-positioned child of the slider wrapper, so any ancestor `overflow`
+(e.g. a `PropertySection` header) clipped it. It now renders in a portal to
+`document.body` with fixed viewport coordinates anchored to the thumb, so it can
+never be clipped. Added `tooltipPlacement?: 'top' | 'bottom'` (default `'top'`).
+The portal is only mounted while dragging, so the idle/drag hot path is
+unchanged. Default visual placement (above the thumb) is unchanged.

--- a/.changeset/etui-spinner-decorative.md
+++ b/.changeset/etui-spinner-decorative.md
@@ -1,0 +1,9 @@
+---
+'entangle-ui': minor
+---
+
+**G2 — `Spinner` `decorative` (live-region opt-out).** Add `decorative?: boolean`
+to `Spinner`. When set, the spinner renders `role="presentation"` + `aria-hidden`
+with no `aria-live`, for use inside an existing live region (e.g. `StatusBar`,
+which is itself `role="status"`) so activity isn't announced twice. Default
+behavior (`role="status"` + `aria-live="polite"`) is unchanged. Additive.

--- a/.changeset/etui-tooltip-positioner-zindex.md
+++ b/.changeset/etui-tooltip-positioner-zindex.md
@@ -1,0 +1,12 @@
+---
+'entangle-ui': patch
+---
+
+**F2 — Tooltip z-index on the Positioner (renders under panels).** The tooltip
+z-index (`--etui-z-tooltip`) was set on the inner `Popup`, trapped inside the
+portaled `Positioner`'s own `position: fixed` stacking context, so a positioned
+sibling at a lower z-index (e.g. an `AppShell` slot at `--etui-z-base`) painted
+over the tooltip. The token now lives on the `Positioner`. Audited the other Base
+UI `Positioner`/`Popup` pairs and applied the same fix to the navigation `Menu`
+and `ContextMenu` (dropdown z-index now on their positioners). `HoverCard`,
+`Select` and `Popover` were already correct (z-index on the positioned element).

--- a/.changeset/etui-viewport-2d-docs.md
+++ b/.changeset/etui-viewport-2d-docs.md
@@ -1,0 +1,8 @@
+---
+'entangle-ui': patch
+---
+
+**G3 — `Viewport` docs lead with "2D only".** The `Viewport` JSDoc, docs page,
+and skill reference now lead with the 2D-only boundary (it owns a 2D pan/zoom
+transform, not a 3D camera) and point to hosting your own WebGL/WebGPU canvas
+for 3D. Docs-only; no API change.

--- a/.claude/skills/entangle-ui/SKILL.md
+++ b/.claude/skills/entangle-ui/SKILL.md
@@ -54,7 +54,7 @@ export function App() {
 - `Text` → [components/primitives/text.md](./components/primitives/text.md) — Versatile typography component with semantic variants, flexible sizing, and text styling for editor interfaces.
 - `TextArea` → [components/primitives/text-area.md](./components/primitives/text-area.md) — Multi-line text input with optional auto-resize, character count, monospace mode, and Input-parity styling.
 - `Tooltip` → [components/primitives/tooltip.md](./components/primitives/tooltip.md) — Contextual information tooltip with flexible positioning, collision handling, and animation support.
-- `Viewport` → [components/primitives/viewport.md](./components/primitives/viewport.md) — Pan/zoom canvas + HTML container for editor-style surfaces — node graphs, timelines, 2D world editors. Multi-layer rendering, world/screen overlays, marquee selection.
+- `Viewport` → [components/primitives/viewport.md](./components/primitives/viewport.md) — **2D only (not a 3D viewport — owns a 2D pan/zoom transform, not a camera; for 3D host your own WebGL canvas).** Pan/zoom canvas + HTML container for editor-style surfaces — node graphs, timelines, 2D world editors. Multi-layer rendering, world/screen overlays, marquee selection.
 - `VisuallyHidden` → [components/primitives/visually-hidden.md](./components/primitives/visually-hidden.md) — Hide content visually while keeping it announced by screen readers.
 
 ### Layout

--- a/.claude/skills/entangle-ui/components/primitives/viewport.md
+++ b/.claude/skills/entangle-ui/components/primitives/viewport.md
@@ -1,6 +1,8 @@
 # Viewport
 
-> Pan/zoom canvas + HTML container for editor-style surfaces — node graphs, timelines, 2D world editors. Multi-layer rendering, world/screen overlays, marquee selection.
+> **2D only (not a 3D viewport).** Pan/zoom canvas + HTML container for editor-style surfaces — node graphs, timelines, 2D world editors. Multi-layer rendering, world/screen overlays, marquee selection.
+
+**2D only.** Despite the name, `Viewport` is **not** a 3D viewport — it owns a 2D pan/zoom transform, not a camera. For 3D, host your own WebGL/WebGPU canvas (e.g. inside an `AppShell.Dock`) and reach for `Viewport` only for 2D editor surfaces.
 
 `Viewport` is the foundation primitive for editor-style 2D surfaces. It combines pan/zoom transform, perf-isolated canvas layers, world-anchored HTML, screen-space overlays, and marquee selection into a single composable primitive. Built to be the base for `NodeGraph`, `Timeline`, and similar surfaces.
 

--- a/docs-site/src/components/demos/shell/AppShellDemo.tsx
+++ b/docs-site/src/components/demos/shell/AppShellDemo.tsx
@@ -1,5 +1,6 @@
 import DemoWrapper from '../DemoWrapper';
 import { AppShell, MenuBar, StatusBar } from '@/components/shell';
+import { Stack } from '@/components/layout';
 import { Text } from '@/components/primitives';
 
 export default function AppShellDemo() {
@@ -38,6 +39,15 @@ export default function AppShellDemo() {
               <Text color="muted">Viewport Area</Text>
             </div>
           </AppShell.Dock>
+          <AppShell.Toolbar position="right">
+            <Stack gap={2} style={{ width: 180, padding: 12 }}>
+              <Text size="xs" color="muted">
+                Inspector
+              </Text>
+              <Text size="sm">Transform</Text>
+              <Text size="sm">Material</Text>
+            </Stack>
+          </AppShell.Toolbar>
           <AppShell.StatusBar>
             <StatusBar>
               <StatusBar.Section side="left">

--- a/docs-site/src/components/demos/shell/MenuBarDemo.tsx
+++ b/docs-site/src/components/demos/shell/MenuBarDemo.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import DemoWrapper from '../DemoWrapper';
 import { MenuBar } from '@/components/shell';
 import { Stack } from '@/components/layout';
@@ -140,6 +141,39 @@ export function MenuBarDisabled() {
         </MenuBar.Menu>
         <MenuBar.Menu label="Debug" disabled>
           <MenuBar.Item>Step Over</MenuBar.Item>
+        </MenuBar.Menu>
+      </MenuBar>
+    </DemoWrapper>
+  );
+}
+
+export function MenuBarCheckable() {
+  const [showGrid, setShowGrid] = useState(true);
+  const [showAxes, setShowAxes] = useState(false);
+  const [shading, setShading] = useState('solid');
+
+  return (
+    <DemoWrapper padding="0" height="340px" withKeyboard>
+      <MenuBar>
+        <MenuBar.Menu label="View">
+          <MenuBar.CheckboxItem
+            checked={showGrid}
+            onCheckedChange={setShowGrid}
+          >
+            Show Grid
+          </MenuBar.CheckboxItem>
+          <MenuBar.CheckboxItem
+            checked={showAxes}
+            onCheckedChange={setShowAxes}
+          >
+            Show Axes
+          </MenuBar.CheckboxItem>
+          <MenuBar.Separator />
+          <MenuBar.RadioGroup value={shading} onValueChange={setShading}>
+            <MenuBar.RadioItem value="solid">Solid</MenuBar.RadioItem>
+            <MenuBar.RadioItem value="wireframe">Wireframe</MenuBar.RadioItem>
+            <MenuBar.RadioItem value="rendered">Rendered</MenuBar.RadioItem>
+          </MenuBar.RadioGroup>
         </MenuBar.Menu>
       </MenuBar>
     </DemoWrapper>

--- a/docs-site/src/content/docs/components/controls/slider.mdx
+++ b/docs-site/src/content/docs/components/controls/slider.mdx
@@ -248,7 +248,14 @@ Hold modifier keys while dragging or using arrow keys for different step sizes:
       name: 'showTooltip',
       type: 'boolean',
       default: 'true',
-      description: 'Show value tooltip while dragging.',
+      description:
+        'Show value tooltip while dragging. The tooltip is portaled to document.body, so it is never clipped by an ancestor with overflow (e.g. a panel/section header).',
+    },
+    {
+      name: 'tooltipPlacement',
+      type: "'top' | 'bottom'",
+      default: "'top'",
+      description: 'Placement of the value tooltip relative to the thumb.',
     },
     {
       name: 'showTicks',

--- a/docs-site/src/content/docs/components/feedback/spinner.mdx
+++ b/docs-site/src/content/docs/components/feedback/spinner.mdx
@@ -162,6 +162,13 @@ When the user enables `prefers-reduced-motion: reduce` in their OS, animation is
       description: 'Show the label visually next to the spinner.',
     },
     {
+      name: 'decorative',
+      type: 'boolean',
+      default: 'false',
+      description:
+        'Render as purely decorative (role="presentation" + aria-hidden, no live region). Use when nested inside an existing live region such as StatusBar.',
+    },
+    {
       name: 'className',
       type: 'string',
       description: 'Additional CSS class names.',
@@ -186,3 +193,13 @@ When the user enables `prefers-reduced-motion: reduce` in their OS, animation is
 - `aria-label` defaults to `"Loading..."` and can be overridden via `label`
 - When `showLabel` is `false`, the label is rendered in a visually-hidden span so it remains discoverable by assistive tech
 - Animation is automatically halted under `prefers-reduced-motion: reduce`
+- Set `decorative` when the spinner sits inside an existing live region (e.g. a `StatusBar`, which is already `role="status"`). It then renders `role="presentation"` + `aria-hidden` with no `aria-live`, so the activity is announced once by the surrounding region instead of twice:
+
+```tsx
+<StatusBar>
+  <StatusBar.Section side="left">
+    <Spinner decorative size="sm" />
+    <StatusBar.Item>Building…</StatusBar.Item>
+  </StatusBar.Section>
+</StatusBar>
+```

--- a/docs-site/src/content/docs/components/primitives/icon-button.mdx
+++ b/docs-site/src/content/docs/components/primitives/icon-button.mdx
@@ -21,12 +21,20 @@ import { IconButton } from 'entangle-ui';
 
 ## Usage
 
+Provide the glyph as `children` or via the `icon` prop — the latter mirrors
+[`Button`](../button/)'s `icon` API so the two components compose the same way.
+When both are set, `icon` wins.
+
 ```tsx
 import { SaveIcon } from 'entangle-ui';
 
+// As children
 <IconButton aria-label="Save file">
   <SaveIcon />
-</IconButton>;
+</IconButton>
+
+// Or via the icon prop (matches Button)
+<IconButton aria-label="Save file" icon={<SaveIcon />} />;
 ```
 
 ## Variants
@@ -168,9 +176,16 @@ The `loading` prop shows a spinner and disables interaction.
 <PropsTable
   props={[
     {
+      name: 'icon',
+      type: 'ReactNode',
+      description:
+        "Icon element to display inside the button, mirroring Button's icon prop. Takes precedence over children when both are set.",
+    },
+    {
       name: 'children',
       type: 'ReactNode',
-      description: 'Icon component to display inside the button.',
+      description:
+        'Icon element to display inside the button. Equivalent to the icon prop (kept for back-compat); icon wins when both are set.',
     },
     {
       name: 'aria-label',

--- a/docs-site/src/content/docs/components/primitives/viewport.mdx
+++ b/docs-site/src/content/docs/components/primitives/viewport.mdx
@@ -7,6 +7,8 @@ import PropsTable from '../../../../components/PropsTable.astro';
 import ComponentPreview from '../../../../components/ComponentPreview.astro';
 import ViewportDemo from '../../../../components/demos/primitives/ViewportDemo';
 
+**2D only.** Despite the name, `Viewport` is **not** a 3D viewport — it owns a 2D pan/zoom transform, not a camera. For 3D, host your own WebGL/WebGPU canvas (for example inside an [`AppShell.Dock`](../../shell/app-shell/)) and reach for `Viewport` only for 2D editor surfaces.
+
 `Viewport` is the foundation primitive for editor-style 2D surfaces. It combines pan/zoom transform, perf-isolated canvas layers, world-anchored HTML, screen-space overlays, and marquee selection into a single composable primitive. Built to be the base for `NodeGraph`, `Timeline`, and similar surfaces.
 
 <ComponentPreview title="Live Preview">

--- a/docs-site/src/content/docs/components/shell/app-shell.mdx
+++ b/docs-site/src/content/docs/components/shell/app-shell.mdx
@@ -45,6 +45,31 @@ AppShell uses a compound component pattern. Each slot renders an appropriate sem
 | `AppShell.Dock`      | `<main>`             | Central content / viewport area  |
 | `AppShell.StatusBar` | `<footer>`           | Bottom status bar                |
 
+## Top Chrome
+
+The `AppShell.MenuBar` slot paints the menu-bar chrome background
+(`--etui-shell-menubar-bg`) by default, and a `MenuBar` placed inside it
+stretches to fill the slot. Together they read as one continuous chrome strip
+instead of a lighter content-width block — no per-app styling required. The
+`MenuBar` triggers inset their hover/active fill from the strip edges so the
+chrome reads cleanly.
+
+## Docking Panels
+
+There is no separate "panel dock" slot. Dock panels — a `PropertyPanel`,
+inspector, outliner, etc. — into the **side toolbar slots**
+(`AppShell.Toolbar position="left"` / `position="right"`). They render `<aside>`
+landmarks, size to their content, and pick up the `sideChromeSeparator`. The
+central `AppShell.Dock` is the viewport/canvas area; for resizable docks compose
+[`SplitPane`](../../layout/split-pane/) inside it.
+
+```tsx
+<AppShell.Dock>{/* viewport / canvas */}</AppShell.Dock>
+<AppShell.Toolbar position="right">
+  <PropertyPanel>{/* docked inspector */}</PropertyPanel>
+</AppShell.Toolbar>
+```
+
 ## Viewport Lock
 
 When `viewportLock` is enabled, the shell locks to the full viewport, preventing page scroll. This is the typical setup for editor applications.
@@ -263,6 +288,23 @@ function ToggleToolbarButton() {
     },
   ]}
 />
+
+## Styling
+
+AppShell defines no component-level CSS custom properties of its own; it is
+re-skinned through the shared `--etui-*` theme tokens below.
+
+### Theme tokens consumed
+
+| Token                                                                                               | Used for                        |
+| --------------------------------------------------------------------------------------------------- | ------------------------------- |
+| `--etui-color-bg-primary`                                                                           | Shell background                |
+| `--etui-color-text-primary`                                                                         | Shell text color                |
+| `--etui-font-family-sans`                                                                           | Shell font family               |
+| `--etui-shell-menubar-bg`                                                                           | Menu-bar slot chrome background |
+| `--etui-color-border-default`                                                                       | Chrome separator borders        |
+| `--etui-shadow-separator-bottom` / `--etui-shadow-separator-right` / `--etui-shadow-separator-left` | Chrome separator shadows        |
+| `--etui-z-base`                                                                                     | Toolbar slot stacking order     |
 
 ## Accessibility
 

--- a/docs-site/src/content/docs/components/shell/menu-bar.mdx
+++ b/docs-site/src/content/docs/components/shell/menu-bar.mdx
@@ -9,6 +9,7 @@ import MenuBarDemo, {
   MenuBarSizes,
   MenuBarSubmenus,
   MenuBarIcons,
+  MenuBarCheckable,
   MenuBarDisabled,
   MenuBarOffset,
 } from '../../../../components/demos/shell/MenuBarDemo';
@@ -69,12 +70,15 @@ import { MenuBar } from 'entangle-ui';
 
 MenuBar uses a compound component pattern with the following sub-components:
 
-| Component           | Purpose                                             |
-| ------------------- | --------------------------------------------------- |
-| `MenuBar.Menu`      | Top-level dropdown trigger and container            |
-| `MenuBar.Item`      | Clickable menu item with optional icon and shortcut |
-| `MenuBar.Sub`       | Nested sub-menu with hover-to-open behavior         |
-| `MenuBar.Separator` | Visual divider between menu items                   |
+| Component              | Purpose                                             |
+| ---------------------- | --------------------------------------------------- |
+| `MenuBar.Menu`         | Top-level dropdown trigger and container            |
+| `MenuBar.Item`         | Clickable menu item with optional icon and shortcut |
+| `MenuBar.CheckboxItem` | Toggleable item with a reserved check-mark gutter   |
+| `MenuBar.RadioGroup`   | Owns the selected value for a set of radio items    |
+| `MenuBar.RadioItem`    | Single-select item within a `RadioGroup`            |
+| `MenuBar.Sub`          | Nested sub-menu with hover-to-open behavior         |
+| `MenuBar.Separator`    | Visual divider between menu items                   |
 
 ## Sizes
 
@@ -137,6 +141,37 @@ import { SaveIcon, CopyIcon } from 'entangle-ui';
 <MenuBar.Item onClick={handleCopy} icon={<CopyIcon />} shortcut="Ctrl+C">
   Copy
 </MenuBar.Item>
+```
+
+## Checkable & Radio Items
+
+Use `MenuBar.CheckboxItem` for independent toggles and `MenuBar.RadioGroup` +
+`MenuBar.RadioItem` for single-select options. Both reserve a leading gutter so
+checked and unchecked rows stay aligned on their label. By default they keep the
+menu open on activation (`closeOnClick={false}`) so several options can be set in
+one pass; pass `closeOnClick` to close after a selection. Each supports both
+controlled (`checked` / `value`) and uncontrolled (`defaultChecked` /
+`defaultValue`) use, mirroring the navigation [`Menu`](../../navigation/menu/).
+
+<ComponentPreview title="Checkable & Radio Items">
+  <MenuBarCheckable client:only="react" />
+</ComponentPreview>
+
+```tsx
+const [showGrid, setShowGrid] = useState(true);
+const [shading, setShading] = useState('solid');
+
+<MenuBar.Menu label="View">
+  <MenuBar.CheckboxItem checked={showGrid} onCheckedChange={setShowGrid}>
+    Show Grid
+  </MenuBar.CheckboxItem>
+  <MenuBar.Separator />
+  <MenuBar.RadioGroup value={shading} onValueChange={setShading}>
+    <MenuBar.RadioItem value="solid">Solid</MenuBar.RadioItem>
+    <MenuBar.RadioItem value="wireframe">Wireframe</MenuBar.RadioItem>
+    <MenuBar.RadioItem value="rendered">Rendered</MenuBar.RadioItem>
+  </MenuBar.RadioGroup>
+</MenuBar.Menu>;
 ```
 
 ## Disabled Items
@@ -301,6 +336,117 @@ The `menuOffset` prop controls the vertical gap between the top-level trigger an
   ]}
 />
 
+### MenuBar.CheckboxItem
+
+<PropsTable
+  props={[
+    { name: 'children', type: 'ReactNode', description: 'Item label text.' },
+    {
+      name: 'checked',
+      type: 'boolean',
+      description: 'Controlled checked state.',
+    },
+    {
+      name: 'defaultChecked',
+      type: 'boolean',
+      default: 'false',
+      description: 'Uncontrolled initial checked state.',
+    },
+    {
+      name: 'onCheckedChange',
+      type: '(checked: boolean) => void',
+      description: 'Called when the checked state toggles.',
+    },
+    {
+      name: 'indicator',
+      type: 'ReactNode',
+      default: '<CheckIcon />',
+      description: 'Indicator shown in the leading gutter when checked.',
+    },
+    {
+      name: 'shortcut',
+      type: 'string',
+      description: 'Keyboard shortcut display text (visual only).',
+    },
+    {
+      name: 'closeOnClick',
+      type: 'boolean',
+      default: 'false',
+      description: 'Whether activating the item closes the menu.',
+    },
+    {
+      name: 'disabled',
+      type: 'boolean',
+      default: 'false',
+      description: 'Whether the item is disabled.',
+    },
+  ]}
+/>
+
+### MenuBar.RadioGroup
+
+<PropsTable
+  props={[
+    {
+      name: 'value',
+      type: 'string',
+      description: 'Controlled selected value.',
+    },
+    {
+      name: 'defaultValue',
+      type: 'string',
+      description: 'Uncontrolled initial value.',
+    },
+    {
+      name: 'onValueChange',
+      type: '(value: string) => void',
+      description: 'Called when the selected value changes.',
+    },
+    {
+      name: 'children',
+      type: 'ReactNode',
+      description: 'MenuBar.RadioItem elements.',
+    },
+  ]}
+/>
+
+### MenuBar.RadioItem
+
+<PropsTable
+  props={[
+    { name: 'children', type: 'ReactNode', description: 'Item label text.' },
+    {
+      name: 'value',
+      type: 'string',
+      required: true,
+      description: 'Value this item represents within its RadioGroup.',
+    },
+    {
+      name: 'indicator',
+      type: 'ReactNode',
+      default: '<CircleIcon />',
+      description: 'Indicator shown in the leading gutter when selected.',
+    },
+    {
+      name: 'shortcut',
+      type: 'string',
+      description: 'Keyboard shortcut display text (visual only).',
+    },
+    {
+      name: 'closeOnClick',
+      type: 'boolean',
+      default: 'false',
+      description: 'Whether activating the item closes the menu.',
+    },
+    {
+      name: 'disabled',
+      type: 'boolean',
+      default: 'false',
+      description: 'Whether the item is disabled.',
+    },
+  ]}
+/>
+
 ### MenuBar.Sub
 
 <PropsTable
@@ -367,9 +513,35 @@ The `menuOffset` prop controls the vertical gap between the top-level trigger an
 - Dropdown panels use `role="menu"` with `aria-label` set to the trigger label
 - Full keyboard navigation:
   - **ArrowLeft / ArrowRight** to move between top-level menus
-  - **ArrowDown / ArrowUp** to navigate items within a dropdown
+  - **ArrowDown / ArrowUp** to navigate items within a dropdown (including checkbox and radio items)
   - **Enter / Space** to open a menu or activate an item
   - **Escape** to close the current dropdown and return focus to the trigger
 - When a menu is open, hovering over another trigger automatically switches to that menu
 - Separators use `role="separator"`
 - Sub-menus use `aria-haspopup="true"` and `aria-expanded` on their trigger
+- `MenuBar.CheckboxItem` uses `role="menuitemcheckbox"` with `aria-checked`; `MenuBar.RadioItem` uses `role="menuitemradio"` with `aria-checked`, wrapped in a `MenuBar.RadioGroup` (`role="group"`)
+
+## Styling
+
+MenuBar defines no component-level CSS custom properties of its own; it is
+re-skinned entirely through the shared `--etui-*` theme tokens below.
+
+### Theme tokens consumed
+
+| Token                                   | Used for                          |
+| --------------------------------------- | --------------------------------- |
+| `--etui-shell-menubar-bg`               | Bar background                    |
+| `--etui-shell-menubar-text`             | Bar text color                    |
+| `--etui-shell-menubar-height`           | Bar height (`size="md"`)          |
+| `--etui-shell-menubar-hover-bg`         | Trigger hover fill                |
+| `--etui-shell-menubar-active-bg`        | Open-trigger fill                 |
+| `--etui-shell-menubar-shortcut-text`    | Shortcut label color              |
+| `--etui-color-bg-elevated`              | Dropdown / sub-menu surface       |
+| `--etui-color-border-default`           | Dropdown border, separators       |
+| `--etui-color-border-focus`             | Focus outline                     |
+| `--etui-color-surface-hover`            | Dropdown item hover/focus fill    |
+| `--etui-color-text-primary`             | Dropdown item text                |
+| `--etui-color-text-secondary`           | Checkbox / radio indicator gutter |
+| `--etui-radius-md` / `--etui-radius-sm` | Dropdown / trigger corner radius  |
+| `--etui-shadow-lg`                      | Dropdown elevation                |
+| `--etui-z-dropdown`                     | Dropdown stacking order           |

--- a/src/components/controls/Slider/Slider.css.ts
+++ b/src/components/controls/Slider/Slider.css.ts
@@ -6,7 +6,6 @@ import { vars } from '@/theme/contract.css';
 // --- Dynamic vars for runtime values ---
 export const fillPercentageVar = createVar();
 export const thumbPercentageVar = createVar();
-export const tooltipPercentageVar = createVar();
 
 // --- Container ---
 export const sliderContainerRecipe = recipe({
@@ -214,12 +213,13 @@ export const tickStyle = style({
 });
 
 // --- Tooltip ---
-export const tooltipRecipe = recipe({
+// Rendered in a portal to `document.body` and positioned with fixed viewport
+// coordinates, so it can never be clipped by an ancestor `overflow` (e.g. a
+// PropertySection header). The thumb anchor (left/top) is supplied inline; the
+// recipe only carries appearance + the placement-dependent transform/arrow.
+export const sliderTooltipRecipe = recipe({
   base: {
-    position: 'absolute',
-    bottom: 'calc(100% + 8px)',
-    left: tooltipPercentageVar,
-    transform: 'translateX(-50%)',
+    position: 'fixed',
     background: vars.colors.background.elevated,
     color: vars.colors.text.primary,
     border: `1px solid ${vars.colors.border.default}`,
@@ -230,39 +230,42 @@ export const tooltipRecipe = recipe({
     whiteSpace: 'nowrap',
     pointerEvents: 'none',
     zIndex: vars.zIndex.tooltip,
-    transition: `all ${vars.transitions.fast}`,
-
-    '@media': {
-      '(prefers-reduced-motion: reduce)': {
-        transition: 'none',
-      },
-    },
-    '::after': {
-      content: '""',
-      position: 'absolute',
-      top: '100%',
-      left: '50%',
-      transform: 'translateX(-50%)',
-      width: 0,
-      height: 0,
-      borderLeft: '4px solid transparent',
-      borderRight: '4px solid transparent',
-      borderTop: `4px solid ${vars.colors.border.default}`,
-    },
   },
   variants: {
-    visible: {
-      true: {
-        opacity: 1,
-        transform: 'translateX(-50%) translateY(0)',
+    placement: {
+      top: {
+        transform: 'translate(-50%, calc(-100% - 8px))',
+        '::after': {
+          content: '""',
+          position: 'absolute',
+          top: '100%',
+          left: '50%',
+          transform: 'translateX(-50%)',
+          width: 0,
+          height: 0,
+          borderLeft: '4px solid transparent',
+          borderRight: '4px solid transparent',
+          borderTop: `4px solid ${vars.colors.border.default}`,
+        },
       },
-      false: {
-        opacity: 0,
-        transform: 'translateX(-50%) translateY(4px)',
+      bottom: {
+        transform: 'translate(-50%, 8px)',
+        '::after': {
+          content: '""',
+          position: 'absolute',
+          bottom: '100%',
+          left: '50%',
+          transform: 'translateX(-50%)',
+          width: 0,
+          height: 0,
+          borderLeft: '4px solid transparent',
+          borderRight: '4px solid transparent',
+          borderBottom: `4px solid ${vars.colors.border.default}`,
+        },
       },
     },
   },
   defaultVariants: {
-    visible: false,
+    placement: 'top',
   },
 });

--- a/src/components/controls/Slider/Slider.test.tsx
+++ b/src/components/controls/Slider/Slider.test.tsx
@@ -91,6 +91,34 @@ describe('Slider', () => {
     });
   });
 
+  describe('Value tooltip', () => {
+    it('portals the value tooltip to document.body so an overflow ancestor cannot clip it', () => {
+      renderWithTheme(
+        <KeyboardContextProvider>
+          <div data-testid="clip" style={{ overflow: 'hidden' }}>
+            <Slider value={50} onChange={vi.fn()} testId="vol" />
+          </div>
+        </KeyboardContextProvider>
+      );
+
+      // Drag-only: the tooltip is not in the tree at rest.
+      expect(screen.queryByTestId('vol-tooltip')).not.toBeInTheDocument();
+
+      fireEvent.mouseDown(screen.getByRole('slider'), { clientX: 10 });
+
+      const tip = screen.getByTestId('vol-tooltip');
+      // Rendered under <body>, escaping the overflow:hidden ancestor.
+      expect(document.body).toContainElement(tip);
+      expect(screen.getByTestId('clip')).not.toContainElement(tip);
+    });
+
+    it('does not render a tooltip when showTooltip is false', () => {
+      renderSlider({ showTooltip: false, testId: 'vol' });
+      fireEvent.mouseDown(screen.getByRole('slider'), { clientX: 10 });
+      expect(screen.queryByTestId('vol-tooltip')).not.toBeInTheDocument();
+    });
+  });
+
   describe('ARIA Attributes', () => {
     it('has role="slider"', () => {
       renderSlider();

--- a/src/components/controls/Slider/Slider.tsx
+++ b/src/components/controls/Slider/Slider.tsx
@@ -3,6 +3,7 @@
 // src/components/controls/Slider/Slider.tsx
 import { assignInlineVars } from '@vanilla-extract/dynamic';
 import React, { useRef, useCallback, useState, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 
 import { FormHelperText } from '@/components/form/FormHelperText';
 import { FormLabel } from '@/components/form/FormLabel';
@@ -20,8 +21,7 @@ import {
   thumbPercentageVar,
   ticksStyle,
   tickStyle,
-  tooltipRecipe,
-  tooltipPercentageVar,
+  sliderTooltipRecipe,
 } from './Slider.css';
 
 import type { BaseComponent, Size } from '@/types/common';
@@ -141,6 +141,14 @@ export interface SliderBaseProps extends Omit<BaseComponent, 'onChange'> {
   showTooltip?: boolean;
 
   /**
+   * Placement of the value tooltip relative to the thumb. The tooltip is
+   * portaled to `document.body`, so it is never clipped by an ancestor's
+   * `overflow`.
+   * @default "top"
+   */
+  tooltipPlacement?: 'top' | 'bottom';
+
+  /**
    * Show tick marks along the track
    * @default false
    */
@@ -258,6 +266,7 @@ export const Slider: React.FC<SliderProps> = ({
   unit,
   formatValue,
   showTooltip = true,
+  tooltipPlacement = 'top',
   showTicks = false,
   tickCount = 5,
   className,
@@ -271,6 +280,12 @@ export const Slider: React.FC<SliderProps> = ({
   const [isDragging, setIsDragging] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
   const [showTooltipState, setShowTooltipState] = useState(false);
+  // Viewport coordinates of the portaled value tooltip (null until a drag
+  // starts). Updated only while dragging so the portal stays off the idle path.
+  const [tooltipPos, setTooltipPos] = useState<{
+    left: number;
+    top: number;
+  } | null>(null);
 
   const sliderRef = useRef<HTMLDivElement>(null);
   const trackRef = useRef<HTMLDivElement>(null);
@@ -347,6 +362,25 @@ export const Slider: React.FC<SliderProps> = ({
   );
 
   /**
+   * Computes the portaled tooltip's viewport position for a (snapped) value,
+   * anchored to the thumb. Reads the same track rect the drag math already
+   * reads, so it adds no extra layout pass per frame.
+   */
+  const updateTooltipPos = useCallback(
+    (v: number): void => {
+      const track = trackRef.current;
+      if (!track) return;
+      const rect = track.getBoundingClientRect();
+      const pct = clamp((v - min) / (max - min), 0, 1);
+      setTooltipPos({
+        left: rect.left + pct * rect.width,
+        top: tooltipPlacement === 'bottom' ? rect.bottom : rect.top,
+      });
+    },
+    [min, max, tooltipPlacement]
+  );
+
+  /**
    * Handle mouse down on track or thumb
    */
   const handleMouseDown = useCallback(
@@ -360,13 +394,21 @@ export const Slider: React.FC<SliderProps> = ({
       // Use the current step size (depends on keyboard modifiers)
       const newValue = positionToValue(event.clientX);
       applyValue(newValue);
+      if (showTooltip) updateTooltipPos(newValue);
 
       dragStartRef.current = {
         startX: event.clientX,
         startValue: newValue,
       };
     },
-    [disabled, readOnly, positionToValue, applyValue, showTooltip]
+    [
+      disabled,
+      readOnly,
+      positionToValue,
+      applyValue,
+      showTooltip,
+      updateTooltipPos,
+    ]
   );
 
   /**
@@ -380,9 +422,10 @@ export const Slider: React.FC<SliderProps> = ({
         // Use the current step size (depends on keyboard modifiers)
         const newValue = positionToValue(event.clientX);
         applyValue(newValue);
+        if (showTooltip) updateTooltipPos(newValue);
       });
     },
-    [isDragging, positionToValue, applyValue]
+    [isDragging, positionToValue, applyValue, showTooltip, updateTooltipPos]
   );
 
   /**
@@ -552,16 +595,21 @@ export const Slider: React.FC<SliderProps> = ({
             </div>
           )}
 
-          {showTooltip && (
-            <div
-              className={tooltipRecipe({ visible: showTooltipState })}
-              style={assignInlineVars({
-                [tooltipPercentageVar]: `${percentage}%`,
-              })}
-            >
-              {displayValue}
-            </div>
-          )}
+          {showTooltip &&
+            showTooltipState &&
+            tooltipPos &&
+            typeof document !== 'undefined' &&
+            createPortal(
+              <div
+                className={sliderTooltipRecipe({ placement: tooltipPlacement })}
+                style={{ left: tooltipPos.left, top: tooltipPos.top }}
+                role="presentation"
+                data-testid={testId ? `${testId}-tooltip` : undefined}
+              >
+                {displayValue}
+              </div>,
+              document.body
+            )}
         </div>
       </InputWrapper>
 

--- a/src/components/feedback/Spinner/Spinner.test.tsx
+++ b/src/components/feedback/Spinner/Spinner.test.tsx
@@ -74,5 +74,22 @@ describe('Spinner', () => {
       renderWithTheme(<Spinner ref={ref} />);
       expect(ref.current).toBeInstanceOf(HTMLElement);
     });
+
+    it('keeps role="status" and aria-live by default', () => {
+      renderWithTheme(<Spinner testId="spinner" />);
+      const el = screen.getByTestId('spinner');
+      expect(el).toHaveAttribute('role', 'status');
+      expect(el).toHaveAttribute('aria-live', 'polite');
+    });
+
+    it('opts out of the live region when decorative', () => {
+      renderWithTheme(<Spinner decorative testId="spinner" />);
+      // No nested live region: role/presentation + aria-hidden, no aria-live.
+      expect(screen.queryByRole('status')).not.toBeInTheDocument();
+      const el = screen.getByTestId('spinner');
+      expect(el).toHaveAttribute('role', 'presentation');
+      expect(el).toHaveAttribute('aria-hidden', 'true');
+      expect(el).not.toHaveAttribute('aria-live');
+    });
   });
 });

--- a/src/components/feedback/Spinner/Spinner.tsx
+++ b/src/components/feedback/Spinner/Spinner.tsx
@@ -42,13 +42,17 @@ function resolveColor(color: SpinnerColor): string {
  * Loading / activity indicator.
  *
  * Announces itself via `role="status"` and `aria-label`; honors
- * `prefers-reduced-motion` by halting animation and dimming the indicator.
+ * `prefers-reduced-motion` by halting animation and dimming the indicator. Pass
+ * `decorative` to opt out of the live region when nested inside one (e.g. a
+ * `StatusBar`).
  *
  * @example
  * ```tsx
  * <Spinner />
  * <Spinner variant="dots" size="lg" />
  * <Spinner showLabel label="Fetching results..." />
+ * // Inside a StatusBar (already role="status"):
+ * <Spinner decorative size="sm" />
  * ```
  */
 export const Spinner = /*#__PURE__*/ React.memo<SpinnerProps>(
@@ -58,6 +62,7 @@ export const Spinner = /*#__PURE__*/ React.memo<SpinnerProps>(
     color = 'accent',
     label = 'Loading...',
     showLabel = false,
+    decorative = false,
     className,
     style,
     testId,
@@ -85,12 +90,16 @@ export const Spinner = /*#__PURE__*/ React.memo<SpinnerProps>(
         </span>
       );
 
+    // Decorative spinners drop the live region (and label) so a surrounding
+    // live region (e.g. StatusBar's role="status") is the single announcer.
+    const semanticProps: React.HTMLAttributes<HTMLSpanElement> = decorative
+      ? { role: 'presentation', 'aria-hidden': true }
+      : { role: 'status', 'aria-live': 'polite', 'aria-label': label };
+
     return (
       <span
         ref={ref}
-        role="status"
-        aria-live="polite"
-        aria-label={label}
+        {...semanticProps}
         className={cx(spinnerRootStyle, className)}
         style={{ ...inlineVars, ...style }}
         data-testid={testId}
@@ -99,7 +108,7 @@ export const Spinner = /*#__PURE__*/ React.memo<SpinnerProps>(
         {indicator}
         {showLabel ? (
           <span className={spinnerLabelStyle}>{label}</span>
-        ) : (
+        ) : decorative ? null : (
           <span className={visuallyHiddenStyle}>{label}</span>
         )}
       </span>

--- a/src/components/feedback/Spinner/Spinner.types.ts
+++ b/src/components/feedback/Spinner/Spinner.types.ts
@@ -39,6 +39,14 @@ export interface SpinnerBaseProps extends BaseComponent<HTMLSpanElement> {
    * @default false
    */
   showLabel?: boolean;
+  /**
+   * Render the spinner as purely decorative: `role="presentation"` +
+   * `aria-hidden`, with no live region. Use when the spinner sits inside an
+   * existing live region (e.g. `StatusBar`, which is itself `role="status"`) so
+   * the activity is not announced twice.
+   * @default false
+   */
+  decorative?: boolean;
 }
 
 export type SpinnerProps = Prettify<SpinnerBaseProps>;

--- a/src/components/navigation/ContextMenu/ContextMenu.tsx
+++ b/src/components/navigation/ContextMenu/ContextMenu.tsx
@@ -3,7 +3,10 @@
 import { ContextMenu as BaseContextMenu } from '@base-ui/react/context-menu';
 import React from 'react';
 
-import { menuContentStyle } from '@/components/navigation/Menu/Menu.css';
+import {
+  menuContentStyle,
+  menuPositionerStyle,
+} from '@/components/navigation/Menu/Menu.css';
 import {
   MenuGapContext,
   DEFAULT_MENU_GAP,
@@ -101,7 +104,7 @@ const ContextMenuContent = ({
   ...rest
 }: ContextMenuContentProps): React.ReactElement => (
   <BaseContextMenu.Portal>
-    <BaseContextMenu.Positioner>
+    <BaseContextMenu.Positioner className={menuPositionerStyle}>
       <BaseContextMenu.Popup
         ref={ref}
         className={cx(menuContentStyle, className)}

--- a/src/components/navigation/Menu/Menu.css.ts
+++ b/src/components/navigation/Menu/Menu.css.ts
@@ -3,6 +3,16 @@ import { style, globalStyle } from '@vanilla-extract/css';
 import { vars } from '@/theme/contract.css';
 
 /**
+ * The portaled, positioned element shared by Menu, submenus and ContextMenu.
+ * Base UI gives it `position: fixed` (its own stacking context), so the dropdown
+ * z-index must live here — not only on the inner Popup (`menuContentStyle`) — or
+ * a positioned sibling at a lower z-index paints over the menu.
+ */
+export const menuPositionerStyle = style({
+  zIndex: vars.zIndex.dropdown,
+});
+
+/**
  * Popup surface shared by Menu, submenus and ContextMenu.
  */
 export const menuContentStyle = style({

--- a/src/components/navigation/Menu/Menu.test.tsx
+++ b/src/components/navigation/Menu/Menu.test.tsx
@@ -5,6 +5,7 @@ import { vi } from 'vitest';
 import { renderWithTheme } from '@/tests/testUtils';
 
 import { Menu } from './Menu';
+import { menuPositionerStyle } from './Menu.css';
 
 // Mock Base UI Menu to avoid @floating-ui positioning loops in jsdom and to
 // keep the popup content mounted so items can be queried without opening.
@@ -45,7 +46,8 @@ vi.mock('@base-ui/react/menu', async () => {
       Root: Frag,
       Trigger,
       Portal: Frag,
-      Positioner: Div,
+      // Pass (not Div) so the className we set on the Positioner is observable.
+      Positioner: Pass,
       Popup: Pass,
       Group: Frag,
       GroupLabel: Div,
@@ -63,6 +65,21 @@ vi.mock('@base-ui/react/menu', async () => {
 });
 
 describe('Menu', () => {
+  describe('Layering', () => {
+    it('puts the dropdown z-index on the positioner so it escapes its own stacking context', () => {
+      const { container } = renderWithTheme(
+        <Menu>
+          <Menu.Trigger>Options</Menu.Trigger>
+          <Menu.Content>
+            <Menu.Item>Copy</Menu.Item>
+          </Menu.Content>
+        </Menu>
+      );
+      // The positioner (not only the popup) carries the dropdown z-index token.
+      expect(container.querySelector(`.${menuPositionerStyle}`)).not.toBeNull();
+    });
+  });
+
   describe('Rendering', () => {
     it('renders the trigger label', () => {
       renderWithTheme(

--- a/src/components/navigation/Menu/Menu.tsx
+++ b/src/components/navigation/Menu/Menu.tsx
@@ -12,6 +12,7 @@ import { cx } from '@/utils/cx';
 
 import {
   menuContentStyle,
+  menuPositionerStyle,
   menuItemStyle,
   itemStartSlotStyle,
   itemLabelStyle,
@@ -184,6 +185,7 @@ const MenuContent = ({
         align={align}
         sideOffset={sideOffset ?? gap}
         alignOffset={alignOffset}
+        className={menuPositionerStyle}
       >
         <BaseMenu.Popup
           ref={ref}

--- a/src/components/primitives/IconButton/IconButton.test.tsx
+++ b/src/components/primitives/IconButton/IconButton.test.tsx
@@ -1,0 +1,87 @@
+import { screen, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+
+import { renderWithTheme } from '@/tests/testUtils';
+
+import { IconButton } from './IconButton';
+
+describe('IconButton', () => {
+  describe('Rendering', () => {
+    it('renders a glyph passed as children', () => {
+      renderWithTheme(
+        <IconButton aria-label="Save">
+          <span data-testid="glyph">x</span>
+        </IconButton>
+      );
+      expect(screen.getByTestId('glyph')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+    });
+
+    it('renders a glyph passed via the icon prop (Button-parity API)', () => {
+      renderWithTheme(
+        <IconButton
+          aria-label="Save"
+          icon={<span data-testid="glyph">x</span>}
+        />
+      );
+      expect(screen.getByTestId('glyph')).toBeInTheDocument();
+    });
+
+    it('prefers the icon prop over children when both are provided', () => {
+      renderWithTheme(
+        <IconButton aria-label="Save" icon={<span data-testid="from-icon" />}>
+          <span data-testid="from-children" />
+        </IconButton>
+      );
+      expect(screen.getByTestId('from-icon')).toBeInTheDocument();
+      expect(screen.queryByTestId('from-children')).not.toBeInTheDocument();
+    });
+
+    it('shows a spinner instead of the glyph while loading', () => {
+      renderWithTheme(
+        <IconButton
+          aria-label="Save"
+          loading
+          icon={<span data-testid="glyph" />}
+        />
+      );
+      expect(screen.queryByTestId('glyph')).not.toBeInTheDocument();
+      expect(screen.getByRole('button')).toBeDisabled();
+    });
+  });
+
+  describe('Interactions', () => {
+    it('calls onClick when clicked', () => {
+      const onClick = vi.fn();
+      renderWithTheme(
+        <IconButton aria-label="Save" icon={<span />} onClick={onClick} />
+      );
+      fireEvent.click(screen.getByRole('button'));
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onClick when disabled', () => {
+      const onClick = vi.fn();
+      renderWithTheme(
+        <IconButton
+          aria-label="Save"
+          icon={<span />}
+          disabled
+          onClick={onClick}
+        />
+      );
+      fireEvent.click(screen.getByRole('button'));
+      expect(onClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('exposes the aria-label and reflects pressed state', () => {
+      renderWithTheme(
+        <IconButton aria-label="Toggle" pressed icon={<span />} />
+      );
+      const btn = screen.getByRole('button', { name: 'Toggle' });
+      expect(btn).toHaveAttribute('aria-pressed', 'true');
+    });
+  });
+});

--- a/src/components/primitives/IconButton/IconButton.tsx
+++ b/src/components/primitives/IconButton/IconButton.tsx
@@ -34,9 +34,22 @@ export interface IconButtonBaseProps extends Omit<
    * Should be an Icon component or similar icon element.
    * The button will automatically size itself based on the icon size.
    *
+   * Equivalent to the `icon` prop — provide the glyph either way. When both are
+   * set, `icon` wins. Kept optional so `<IconButton icon={…} />` matches
+   * `Button`'s `icon` API.
+   *
    * @example <SaveIcon />, <AddIcon />
    */
-  children: React.ReactNode;
+  children?: React.ReactNode;
+
+  /**
+   * Icon element to display inside the button, mirroring `Button`'s `icon`
+   * prop so the two components share one API. Takes precedence over
+   * `children` when both are provided.
+   *
+   * @example <SaveIcon />, <AddIcon />
+   */
+  icon?: React.ReactNode;
 
   /**
    * Button size using standard library sizing
@@ -162,6 +175,7 @@ export type IconButtonProps = Prettify<IconButtonBaseProps>;
 export const IconButton = /*#__PURE__*/ React.memo<IconButtonProps>(
   ({
     children,
+    icon,
     className,
     size = 'md',
     variant = 'ghost',
@@ -176,6 +190,8 @@ export const IconButton = /*#__PURE__*/ React.memo<IconButtonProps>(
     ref,
     ...props
   }) => {
+    // `icon` mirrors Button's API; fall back to `children` for back-compat.
+    const glyph = icon ?? children;
     return (
       <button
         ref={ref}
@@ -196,11 +212,7 @@ export const IconButton = /*#__PURE__*/ React.memo<IconButtonProps>(
         style={style}
         {...props}
       >
-        {loading ? (
-          <div className={loadingSpinnerRecipe({ size })} />
-        ) : (
-          children
-        )}
+        {loading ? <div className={loadingSpinnerRecipe({ size })} /> : glyph}
       </button>
     );
   }

--- a/src/components/primitives/Tooltip/Tooltip.css.ts
+++ b/src/components/primitives/Tooltip/Tooltip.css.ts
@@ -32,6 +32,16 @@ export const tooltipContentStyle = style({
   },
 });
 
+/**
+ * The portaled, positioned element. Base UI gives it `position: fixed`, which
+ * creates its own stacking context — so the tooltip z-index must live here, not
+ * only on the inner Popup. Without it a positioned sibling at a lower z-index
+ * (e.g. an AppShell slot at `--etui-z-base`) paints over the tooltip.
+ */
+export const tooltipPositionerStyle = style({
+  zIndex: vars.zIndex.tooltip,
+});
+
 export const tooltipTriggerStyle = style({
   display: 'inline-block',
   cursor: 'pointer',

--- a/src/components/primitives/Tooltip/Tooltip.test.tsx
+++ b/src/components/primitives/Tooltip/Tooltip.test.tsx
@@ -3,8 +3,27 @@ import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import { renderWithTheme } from '@/tests/testUtils';
 import { Tooltip } from './Tooltip';
+import { tooltipPositionerStyle } from './Tooltip.css';
 
 describe('Tooltip', () => {
+  describe('Layering', () => {
+    it('applies the tooltip z-index to the portaled positioner, not only the popup', async () => {
+      const user = userEvent.setup({ delay: null });
+      renderWithTheme(
+        <Tooltip title="Tip" testId="tt" delay={0}>
+          <button>Trigger</button>
+        </Tooltip>
+      );
+      await user.hover(screen.getByText('Trigger'));
+      const popup = await screen.findByTestId('tt');
+      // Base UI structure: the Positioner is the popup's parent. The z-index
+      // token must live there so it escapes the positioner's own (fixed)
+      // stacking context and competes at the document root.
+      const positioner = popup.parentElement;
+      expect(positioner?.className).toContain(tooltipPositionerStyle);
+    });
+  });
+
   describe('Reduced motion', () => {
     const originalMatchMedia = window.matchMedia;
 

--- a/src/components/primitives/Tooltip/Tooltip.tsx
+++ b/src/components/primitives/Tooltip/Tooltip.tsx
@@ -7,7 +7,11 @@ import React from 'react';
 import { cx } from '@/utils/cx';
 
 import { ArrowSvg, StyledTooltipArrow } from './Arrow';
-import { tooltipContentStyle, tooltipTriggerStyle } from './Tooltip.css';
+import {
+  tooltipContentStyle,
+  tooltipTriggerStyle,
+  tooltipPositionerStyle,
+} from './Tooltip.css';
 import {
   CollisionAvoidance,
   TooltipAnimation,
@@ -327,7 +331,13 @@ export const Tooltip: React.FC<TooltipProps> = ({
         </BaseTooltip.Trigger>
 
         <BaseTooltip.Portal>
-          <BaseTooltip.Positioner {...finalPositionerProps}>
+          <BaseTooltip.Positioner
+            {...finalPositionerProps}
+            className={cx(
+              tooltipPositionerStyle,
+              finalPositionerProps.className
+            )}
+          >
             <BaseTooltip.Popup
               render={props => (
                 <div

--- a/src/components/primitives/Tooltip/Tooltip.tsx
+++ b/src/components/primitives/Tooltip/Tooltip.tsx
@@ -288,6 +288,20 @@ export const Tooltip: React.FC<TooltipProps> = ({
     }
   }
 
+  // Merge our z-index positioner class with any caller-provided className,
+  // honoring Base UI's function-className form (power-user `positionerProps`).
+  const incomingPositionerClassName = finalPositionerProps.className;
+  let positionerClassName: typeof incomingPositionerClassName;
+  if (typeof incomingPositionerClassName === 'function') {
+    positionerClassName = state =>
+      cx(tooltipPositionerStyle, incomingPositionerClassName(state));
+  } else {
+    positionerClassName = cx(
+      tooltipPositionerStyle,
+      incomingPositionerClassName
+    );
+  }
+
   // Handle cursor tracking. Copy into a local object instead of mutating the
   // caller-owned `rootProps` prop.
   const finalRootProps: Partial<BaseTooltipRootProps> = { ...rootProps };
@@ -333,10 +347,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
         <BaseTooltip.Portal>
           <BaseTooltip.Positioner
             {...finalPositionerProps}
-            className={cx(
-              tooltipPositionerStyle,
-              finalPositionerProps.className
-            )}
+            className={positionerClassName}
           >
             <BaseTooltip.Popup
               render={props => (

--- a/src/components/primitives/viewport/Viewport.tsx
+++ b/src/components/primitives/viewport/Viewport.tsx
@@ -69,8 +69,11 @@ function categorizeChildren(children: React.ReactNode): CategorizedChildren {
 }
 
 /**
- * Viewport — pan/zoom canvas + HTML container for editor-style surfaces
- * such as node graphs, timelines, and 2D world editors.
+ * Viewport — **2D only.** A pan/zoom canvas + HTML container for editor-style
+ * surfaces such as node graphs, timelines, and 2D world editors. Despite the
+ * name it is *not* a 3D viewport: it owns a 2D pan/zoom transform, not a camera.
+ * For 3D, host your own WebGL/WebGPU canvas (e.g. inside an `AppShell.Dock`) and
+ * reach for `Viewport` only for 2D editor surfaces.
  *
  * Composes:
  * - Multiple perf-isolated `<ViewportLayer>` canvases (one draw cycle each).

--- a/src/components/shell/AppShell/AppShell.css.ts
+++ b/src/components/shell/AppShell/AppShell.css.ts
@@ -48,6 +48,11 @@ export const shellRoot = style({
 
 export const menuBarSlot = style({
   gridArea: 'menubar',
+  // Paint the menu-bar chrome background on the slot itself so the top chrome
+  // reads as one continuous strip even when the MenuBar does not fill every
+  // pixel (e.g. trailing content, different MenuBar size). Matches
+  // `MenuBar`'s own `vars.shell.menuBar.bg`.
+  background: vars.shell.menuBar.bg,
 });
 
 export const toolbarTopSlot = recipe({

--- a/src/components/shell/AppShell/AppShell.test.tsx
+++ b/src/components/shell/AppShell/AppShell.test.tsx
@@ -2,6 +2,7 @@ import { screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { renderWithTheme } from '@/tests/testUtils';
 import { AppShell, useAppShell } from './AppShell';
+import { menuBarSlot } from './AppShell.css';
 import React from 'react';
 
 describe('AppShell', () => {
@@ -111,6 +112,20 @@ describe('AppShell', () => {
       const header = container.querySelector('header');
       expect(header).toBeInTheDocument();
       expect(header).toHaveTextContent('Menu');
+    });
+
+    it('paints the menu-bar chrome background on the menu bar slot', () => {
+      const { container } = renderWithTheme(
+        <AppShell>
+          <AppShell.MenuBar>Menu</AppShell.MenuBar>
+          <AppShell.Dock>Content</AppShell.Dock>
+        </AppShell>
+      );
+      // The chrome-bg class lands on the <header> slot so the top chrome reads
+      // as one strip (VE class styles aren't resolved in jsdom, so assert the
+      // class is applied rather than the computed color).
+      const header = container.querySelector('header');
+      expect(header?.className).toContain(menuBarSlot);
     });
 
     it('uses main for dock slot', () => {

--- a/src/components/shell/MenuBar/MenuBar.css.ts
+++ b/src/components/shell/MenuBar/MenuBar.css.ts
@@ -14,6 +14,9 @@ export const menuBarRoot = recipe({
     padding: `0 ${vars.spacing.sm}`,
     userSelect: 'none',
     flexShrink: 0,
+    // Fill the host slot (e.g. AppShell.MenuBar) so the bar reads as one chrome
+    // strip rather than a content-width block on a darker background.
+    width: '100%',
   },
   variants: {
     size: {
@@ -32,6 +35,10 @@ export const menuBarRoot = recipe({
 
 export const menuContainer = style({
   position: 'relative',
+  // Center the trigger so its hover/active fill is inset from the chrome edges
+  // (the trigger is shorter than the full bar height).
+  display: 'flex',
+  alignItems: 'center',
   height: '100%',
 });
 
@@ -39,8 +46,11 @@ export const trigger = recipe({
   base: {
     display: 'inline-flex',
     alignItems: 'center',
-    height: '100%',
-    padding: `0 ${vars.spacing.md}`,
+    // Vertical padding (not full height) keeps the hover/active fill inset from
+    // the top/bottom chrome edges; the rounded corners make the fill read as a
+    // pill rather than a full-height block.
+    padding: `${vars.spacing.xs} ${vars.spacing.md}`,
+    borderRadius: vars.borderRadius.sm,
     border: 'none',
     color: 'inherit',
     font: 'inherit',
@@ -130,6 +140,20 @@ export const shortcut = style({
   marginLeft: 'auto',
   color: vars.shell.menuBar.shortcutText,
   fontSize: vars.typography.fontSize.xs,
+});
+
+/**
+ * Reserved leading gutter for checkable/radio items so checked and unchecked
+ * rows align on their label regardless of indicator visibility.
+ */
+export const indicatorSlot = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '16px',
+  height: '16px',
+  flexShrink: 0,
+  color: vars.colors.text.secondary,
 });
 
 export const separator = style({

--- a/src/components/shell/MenuBar/MenuBar.test.tsx
+++ b/src/components/shell/MenuBar/MenuBar.test.tsx
@@ -168,6 +168,130 @@ describe('MenuBar', () => {
     });
   });
 
+  describe('Checkable items', () => {
+    it('renders a checkbox item with role and unchecked state', () => {
+      renderWithTheme(
+        <MenuBar>
+          <MenuBar.Menu label="View">
+            <MenuBar.CheckboxItem>Show Grid</MenuBar.CheckboxItem>
+          </MenuBar.Menu>
+        </MenuBar>
+      );
+      fireEvent.click(screen.getByText('View'));
+      const item = screen.getByRole('menuitemcheckbox', { name: 'Show Grid' });
+      expect(item).toHaveAttribute('aria-checked', 'false');
+    });
+
+    it('toggles aria-checked and fires onCheckedChange (uncontrolled)', () => {
+      const onCheckedChange = vi.fn();
+      renderWithTheme(
+        <MenuBar>
+          <MenuBar.Menu label="View">
+            <MenuBar.CheckboxItem onCheckedChange={onCheckedChange}>
+              Show Grid
+            </MenuBar.CheckboxItem>
+          </MenuBar.Menu>
+        </MenuBar>
+      );
+      fireEvent.click(screen.getByText('View'));
+      const item = screen.getByRole('menuitemcheckbox', { name: 'Show Grid' });
+      fireEvent.click(item);
+      expect(onCheckedChange).toHaveBeenCalledWith(true);
+      expect(item).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('keeps the menu open after toggling a checkbox by default', () => {
+      renderWithTheme(
+        <MenuBar>
+          <MenuBar.Menu label="View">
+            <MenuBar.CheckboxItem>Show Grid</MenuBar.CheckboxItem>
+          </MenuBar.Menu>
+        </MenuBar>
+      );
+      fireEvent.click(screen.getByText('View'));
+      fireEvent.click(
+        screen.getByRole('menuitemcheckbox', { name: 'Show Grid' })
+      );
+      expect(
+        screen.getByRole('menuitemcheckbox', { name: 'Show Grid' })
+      ).toBeInTheDocument();
+    });
+
+    it('respects controlled checked state', () => {
+      const onCheckedChange = vi.fn();
+      renderWithTheme(
+        <MenuBar>
+          <MenuBar.Menu label="View">
+            <MenuBar.CheckboxItem
+              checked={false}
+              onCheckedChange={onCheckedChange}
+            >
+              Show Grid
+            </MenuBar.CheckboxItem>
+          </MenuBar.Menu>
+        </MenuBar>
+      );
+      fireEvent.click(screen.getByText('View'));
+      const item = screen.getByRole('menuitemcheckbox', { name: 'Show Grid' });
+      expect(item).toHaveAttribute('aria-checked', 'false');
+      fireEvent.click(item);
+      expect(onCheckedChange).toHaveBeenCalledWith(true);
+      // Controlled: stays unchecked until the parent updates `checked`.
+      expect(item).toHaveAttribute('aria-checked', 'false');
+    });
+
+    it('radio group single-selects and fires onValueChange', () => {
+      const onValueChange = vi.fn();
+      renderWithTheme(
+        <MenuBar>
+          <MenuBar.Menu label="View">
+            <MenuBar.RadioGroup
+              defaultValue="solid"
+              onValueChange={onValueChange}
+            >
+              <MenuBar.RadioItem value="solid">Solid</MenuBar.RadioItem>
+              <MenuBar.RadioItem value="wireframe">Wireframe</MenuBar.RadioItem>
+            </MenuBar.RadioGroup>
+          </MenuBar.Menu>
+        </MenuBar>
+      );
+      fireEvent.click(screen.getByText('View'));
+      const solid = screen.getByRole('menuitemradio', { name: 'Solid' });
+      const wireframe = screen.getByRole('menuitemradio', {
+        name: 'Wireframe',
+      });
+      expect(solid).toHaveAttribute('aria-checked', 'true');
+      expect(wireframe).toHaveAttribute('aria-checked', 'false');
+
+      fireEvent.click(wireframe);
+      expect(onValueChange).toHaveBeenCalledWith('wireframe');
+      expect(wireframe).toHaveAttribute('aria-checked', 'true');
+      expect(solid).toHaveAttribute('aria-checked', 'false');
+    });
+
+    it('reserves a leading gutter so checkable items align', () => {
+      renderWithTheme(
+        <MenuBar>
+          <MenuBar.Menu label="View">
+            <MenuBar.CheckboxItem checked>Show Grid</MenuBar.CheckboxItem>
+            <MenuBar.CheckboxItem>Show Axes</MenuBar.CheckboxItem>
+          </MenuBar.Menu>
+        </MenuBar>
+      );
+      fireEvent.click(screen.getByText('View'));
+      // Both items carry the same number of leading slots (the reserved gutter
+      // is always rendered, checked or not).
+      const checked = screen.getByRole('menuitemcheckbox', {
+        name: 'Show Grid',
+      });
+      const unchecked = screen.getByRole('menuitemcheckbox', {
+        name: 'Show Axes',
+      });
+      expect(checked.firstElementChild).not.toBeNull();
+      expect(unchecked.firstElementChild).not.toBeNull();
+    });
+  });
+
   describe('Accessibility', () => {
     it('triggers have aria-haspopup and aria-expanded', () => {
       renderMenuBar();

--- a/src/components/shell/MenuBar/MenuBar.tsx
+++ b/src/components/shell/MenuBar/MenuBar.tsx
@@ -12,6 +12,8 @@ import React, {
   useMemo,
 } from 'react';
 
+import { CheckIcon } from '@/components/Icons/CheckIcon';
+import { CircleIcon } from '@/components/Icons/CircleIcon';
 import { cx } from '@/utils/cx';
 
 import {
@@ -25,6 +27,7 @@ import {
   subTrigger,
   subDropdown,
   subContainer,
+  indicatorSlot,
 } from './MenuBar.css';
 
 import type {
@@ -34,6 +37,10 @@ import type {
   MenuBarSubProps,
   MenuBarSeparatorProps,
   MenuBarContextValue,
+  MenuBarCheckboxItemProps,
+  MenuBarRadioGroupProps,
+  MenuBarRadioItemProps,
+  MenuBarRadioGroupContextValue,
 } from './MenuBar.types';
 
 // --- Context ---
@@ -52,7 +59,8 @@ const useMenuBar = () => useContext(MenuBarContext);
 
 const SUBMENU_CLOSE_DELAY = 150;
 
-const MENU_ITEM_SELECTOR = '[role="menuitem"]:not(:disabled)';
+const MENU_ITEM_SELECTOR =
+  '[role="menuitem"]:not(:disabled), [role="menuitemcheckbox"]:not(:disabled), [role="menuitemradio"]:not(:disabled)';
 
 const ChevronRight = () => (
   <span
@@ -110,6 +118,161 @@ const MenuBarItem: React.FC<MenuBarItemProps> = ({
 };
 
 MenuBarItem.displayName = 'MenuBar.Item';
+
+// --- Checkable items (checkbox / radio) ---
+
+const MenuBarRadioContext =
+  /*#__PURE__*/ createContext<MenuBarRadioGroupContextValue | null>(null);
+
+const MenuBarCheckboxItem: React.FC<MenuBarCheckboxItemProps> = ({
+  checked,
+  defaultChecked = false,
+  onCheckedChange,
+  shortcut: shortcutText,
+  indicator = <CheckIcon size="sm" />,
+  closeOnClick = false,
+  disabled = false,
+  children,
+
+  className,
+  style,
+  testId,
+  ref,
+  ...rest
+}) => {
+  const { setOpenMenuId } = useMenuBar();
+  const [internalChecked, setInternalChecked] = useState(defaultChecked);
+  const isControlled = checked !== undefined;
+  const isChecked = isControlled ? checked : internalChecked;
+
+  const handleClick = useCallback(() => {
+    const next = !isChecked;
+    if (!isControlled) setInternalChecked(next);
+    onCheckedChange?.(next);
+    if (closeOnClick) setOpenMenuId(null);
+  }, [isChecked, isControlled, onCheckedChange, closeOnClick, setOpenMenuId]);
+
+  return (
+    <button
+      role="menuitemcheckbox"
+      aria-checked={isChecked}
+      onClick={handleClick}
+      disabled={disabled}
+      className={cx(menuItem, className)}
+      style={style}
+      data-testid={testId}
+      ref={ref}
+      type="button"
+      tabIndex={-1}
+      {...rest}
+    >
+      <span className={indicatorSlot} aria-hidden="true">
+        {isChecked ? indicator : null}
+      </span>
+      <span>{children}</span>
+      {shortcutText && <span className={shortcut}>{shortcutText}</span>}
+    </button>
+  );
+};
+
+MenuBarCheckboxItem.displayName = 'MenuBar.CheckboxItem';
+
+const MenuBarRadioGroup: React.FC<MenuBarRadioGroupProps> = ({
+  value,
+  defaultValue,
+  onValueChange,
+  children,
+
+  className,
+  style,
+  testId,
+  ref,
+  ...rest
+}) => {
+  const [internalValue, setInternalValue] = useState<string | undefined>(
+    defaultValue
+  );
+  const isControlled = value !== undefined;
+  const selectedValue = isControlled ? value : internalValue;
+
+  const setValue = useCallback(
+    (next: string) => {
+      if (!isControlled) setInternalValue(next);
+      onValueChange?.(next);
+    },
+    [isControlled, onValueChange]
+  );
+
+  const contextValue = useMemo(
+    () => ({ value: selectedValue, setValue }),
+    [selectedValue, setValue]
+  );
+
+  return (
+    <MenuBarRadioContext.Provider value={contextValue}>
+      <div
+        role="group"
+        className={className}
+        style={style}
+        data-testid={testId}
+        ref={ref}
+        {...rest}
+      >
+        {children}
+      </div>
+    </MenuBarRadioContext.Provider>
+  );
+};
+
+MenuBarRadioGroup.displayName = 'MenuBar.RadioGroup';
+
+const MenuBarRadioItem: React.FC<MenuBarRadioItemProps> = ({
+  value,
+  shortcut: shortcutText,
+  indicator = <CircleIcon size="sm" />,
+  closeOnClick = false,
+  disabled = false,
+  children,
+
+  className,
+  style,
+  testId,
+  ref,
+  ...rest
+}) => {
+  const { setOpenMenuId } = useMenuBar();
+  const group = useContext(MenuBarRadioContext);
+  const isChecked = group?.value === value;
+
+  const handleClick = useCallback(() => {
+    group?.setValue(value);
+    if (closeOnClick) setOpenMenuId(null);
+  }, [group, value, closeOnClick, setOpenMenuId]);
+
+  return (
+    <button
+      role="menuitemradio"
+      aria-checked={isChecked}
+      onClick={handleClick}
+      disabled={disabled}
+      className={cx(menuItem, className)}
+      style={style}
+      data-testid={testId}
+      ref={ref}
+      type="button"
+      tabIndex={-1}
+      {...rest}
+    >
+      <span className={indicatorSlot} aria-hidden="true">
+        {isChecked ? indicator : null}
+      </span>
+      <span>{children}</span>
+      {shortcutText && <span className={shortcut}>{shortcutText}</span>}
+    </button>
+  );
+};
+
+MenuBarRadioItem.displayName = 'MenuBar.RadioItem';
 
 const MenuBarSub: React.FC<MenuBarSubProps> = ({
   label,
@@ -480,6 +643,9 @@ MenuBarRoot.displayName = 'MenuBar';
 export const MenuBar = /*#__PURE__*/ Object.assign(MenuBarRoot, {
   Menu: MenuBarMenu,
   Item: MenuBarItem,
+  CheckboxItem: MenuBarCheckboxItem,
+  RadioGroup: MenuBarRadioGroup,
+  RadioItem: MenuBarRadioItem,
   Sub: MenuBarSub,
   Separator: MenuBarSeparator,
 });

--- a/src/components/shell/MenuBar/MenuBar.types.ts
+++ b/src/components/shell/MenuBar/MenuBar.types.ts
@@ -53,6 +53,68 @@ export type MenuBarSubProps = Prettify<MenuBarSubBaseProps>;
 
 export type MenuBarSeparatorProps = Prettify<BaseComponent>;
 
+export interface MenuBarCheckboxItemBaseProps extends Omit<
+  BaseComponent<HTMLButtonElement>,
+  'onClick'
+> {
+  /** Controlled checked state. */
+  checked?: boolean;
+  /** Uncontrolled initial checked state. @default false */
+  defaultChecked?: boolean;
+  /** Called when the checked state toggles. */
+  onCheckedChange?: (checked: boolean) => void;
+  /** Keyboard shortcut display text (not bound). */
+  shortcut?: string;
+  /** Indicator shown when checked. @default CheckIcon */
+  indicator?: ReactNode;
+  /** Whether activating the item closes the menu. @default false */
+  closeOnClick?: boolean;
+  /** Disabled state. */
+  disabled?: boolean;
+  /** Item label. */
+  children?: ReactNode;
+}
+export type MenuBarCheckboxItemProps = Prettify<MenuBarCheckboxItemBaseProps>;
+
+export interface MenuBarRadioGroupBaseProps extends Omit<
+  BaseComponent,
+  'onChange'
+> {
+  /** Controlled selected value. */
+  value?: string;
+  /** Uncontrolled initial value. */
+  defaultValue?: string;
+  /** Called when the selected value changes. */
+  onValueChange?: (value: string) => void;
+  /** Radio items. */
+  children?: ReactNode;
+}
+export type MenuBarRadioGroupProps = Prettify<MenuBarRadioGroupBaseProps>;
+
+export interface MenuBarRadioItemBaseProps extends Omit<
+  BaseComponent<HTMLButtonElement>,
+  'onClick'
+> {
+  /** Value this item represents within its `MenuBar.RadioGroup`. */
+  value: string;
+  /** Keyboard shortcut display text (not bound). */
+  shortcut?: string;
+  /** Indicator shown when selected. @default CircleIcon */
+  indicator?: ReactNode;
+  /** Whether activating the item closes the menu. @default false */
+  closeOnClick?: boolean;
+  /** Disabled state. */
+  disabled?: boolean;
+  /** Item label. */
+  children?: ReactNode;
+}
+export type MenuBarRadioItemProps = Prettify<MenuBarRadioItemBaseProps>;
+
+export interface MenuBarRadioGroupContextValue {
+  value: string | undefined;
+  setValue: (value: string) => void;
+}
+
 export interface MenuBarContextValue {
   size: MenuBarSize;
   menuOffset: number;

--- a/src/components/shell/MenuBar/index.ts
+++ b/src/components/shell/MenuBar/index.ts
@@ -5,6 +5,9 @@ export type {
   MenuBarSize,
   MenuBarMenuProps,
   MenuBarItemProps,
+  MenuBarCheckboxItemProps,
+  MenuBarRadioGroupProps,
+  MenuBarRadioItemProps,
   MenuBarSubProps,
   MenuBarSeparatorProps,
 } from './MenuBar.types';


### PR DESCRIPTION
Implements the remaining tasks **E1 → G3** from `docs/plans/2026-06-23-feedback-remediation.md` (A1–D3 and H1 already landed). Each task ships code + tests + docs/demo + a changeset.

## Workstream E — Shell
- **E1 — AppShell top-chrome + MenuBar fill/inset.** `AppShell.MenuBar` slot now paints the menu-bar chrome background (`--etui-shell-menubar-bg`) and `MenuBar` stretches to fill its slot, so the top chrome reads as one continuous strip instead of a lighter content-width block. Triggers inset their hover/active fill (rounded, vertically centered). Docs answer the open question: side toolbar slots (`AppShell.Toolbar position="left|right"`) are the home for docked panels. _Visual default change, no API change._
- **E2 — MenuBar checkable / radio items.** New `MenuBar.CheckboxItem` and `MenuBar.RadioGroup` + `MenuBar.RadioItem`, mirroring the navigation `Menu` API. Reserved leading check-mark gutter for alignment, `menuitemcheckbox`/`menuitemradio` roles with `aria-checked`, arrow-key navigation, controlled + uncontrolled, `closeOnClick` (default `false`).

## Workstream F — Overlays
- **F2 — Tooltip z-index on the Positioner.** The z-index token sat on the inner `Popup`, trapped inside the portaled `Positioner`'s `position: fixed` stacking context, so positioned siblings (e.g. an `AppShell` slot at `--etui-z-base`) painted over tooltips. Moved onto the `Positioner`. Audited the other Base UI `Positioner`/`Popup` pairs and applied the same fix to navigation `Menu` and `ContextMenu`. `HoverCard`/`Select`/`Popover` were already correct (z-index on the positioned element).
- **F1 — Slider value tooltip → portal.** The drag tooltip was an absolutely-positioned wrapper child clipped by any ancestor `overflow` (e.g. a section header). It now renders in a portal to `document.body` with fixed thumb-anchored coordinates. New `tooltipPlacement` (`'top' | 'bottom'`). The portal mounts only while dragging, so the hot path is unchanged; default placement (above the thumb) is unchanged.

## Workstream G — Polish / a11y / typing
- **G1 — Align Button/IconButton icon API.** `IconButton` accepts an optional `icon` prop mirroring `Button` (children still works; `icon` wins when both set). Adds the previously-missing `IconButton` test file.
- **G2 — Spinner `decorative`.** `role="presentation"` + `aria-hidden`, no live region — for nesting inside an existing live region like `StatusBar`. Default behavior unchanged.
- **G3 — Viewport docs lead with "2D only".** JSDoc, docs page, and skill reference now lead with the 2D-only boundary (a 2D pan/zoom transform, not a 3D camera) and point to hosting your own WebGL canvas for 3D. Docs-only.

## Verification
- `npm run lint` — clean
- `npm run type-check` — clean
- `npm test` — 153 files, 3223 passed / 2 skipped
- New tests: MenuBar checkable/radio, AppShell chrome class, Tooltip/Menu positioner z-index, Slider portal tooltip, IconButton (new file), Spinner decorative

## Notes / friction
- A `package-lock.json` `version` drift (0.10.0 → 0.11.0) surfaced during install; reverted to leave it to the changeset release process.
- Per the plan these are normally one-PR-per-task; bundled here per the request to clear all pending E1–G3 work in one branch. Each task has its own changeset for an accurate changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LM3knnS1pSyywRB3T5QRph

---
_Generated by [Claude Code](https://claude.ai/code/session_01LM3knnS1pSyywRB3T5QRph)_