### PR TITLE
fix(build): keep entangle-ui/styles.css from being tree-shaken out of prod builds

### DIFF
--- a/.changeset/styles-css-tree-shaking.md
+++ b/.changeset/styles-css-tree-shaking.md
@@ -1,0 +1,21 @@
+---
+'entangle-ui': patch
+---
+
+Fix `entangle-ui/styles.css` being tree-shaken out of production builds.
+
+The `./styles.css` export resolved to `dist/esm/styles.js` — a JS shim whose
+only job is to `import` the dark-theme tokens + global-scrollbar stylesheets for
+their side effects. But the package's `sideEffects` allowlist only matches
+`*.css`, `*.css.ts`, and `*.css.js`, so a plain `styles.js` (which exports
+nothing) was flagged side-effect-free and dropped by production bundlers. The
+canonical `import 'entangle-ui/styles.css'` setup then shipped **zero** `--etui-*`
+token definitions: no colours, no fonts, and menu/tooltip popups with no
+background or stacking. Dev was unaffected because dev servers don't tree-shake,
+so the failure only surfaced in `build`/`preview`.
+
+The stylesheet entry is now emitted as `dist/esm/styles.css.js`, which matches
+the existing `*.css.js` side-effect glob (the same bucket as every component's
+compiled style module), so the import survives production tree-shaking and the
+dark theme lands on `:root` in dev and prod alike. No source or API change is
+required in consumer apps.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
       "types": "./dist/types/index.d.ts",
       "default": "./dist/esm/index.js"
     },
-    "./styles.css": "./dist/esm/styles.js",
+    "./styles.css": "./dist/esm/styles.css.js",
     "./palettes": {
       "types": "./dist/types/palettes.d.ts",
       "default": "./dist/esm/palettes.js"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -56,9 +56,19 @@ export default [
       'theme/index': 'src/theme/index.ts',
       'theme-values': 'src/theme-values.ts',
       // Canonical stylesheet entry exposed as `entangle-ui/styles.css`. A
-      // side-effect-only module that registers the dark theme `:root` vars +
-      // global scrollbar rules so consumers can load the theme with one import.
-      styles: 'src/styles.ts',
+      // side-effect-only module (zero exports) that registers the dark theme
+      // `:root` vars + global scrollbar rules so consumers load the theme with
+      // a single import.
+      //
+      // The output is named `styles.css.js`, NOT `styles.js`. package.json
+      // `sideEffects` only whitelists `*.css`, `*.css.ts`, `*.css.js`; a bare
+      // `styles.js` matches none of them. Because this module exports nothing,
+      // a consumer's production bundler would then flag it side-effect-free and
+      // tree-shake the whole `import 'entangle-ui/styles.css'` away — dropping
+      // every `--etui-*` token (broken theme in prod builds; dev is unaffected
+      // because dev servers don't tree-shake). The `.css.js` suffix lands it in
+      // the same proven side-effect bucket as the component `*.css.js` modules.
+      'styles.css': 'src/styles.ts',
     },
     output: {
       dir: 'dist/esm',

--- a/src/styles.test.ts
+++ b/src/styles.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
 // Import ONLY the canonical stylesheet entry. Vitest isolates each test file,
@@ -39,6 +42,69 @@ describe('entangle-ui/styles.css (canonical theme entry)', () => {
     expect(hasScrollbarRule).toBe(true);
   });
 });
+
+/**
+ * Packaging invariant: `entangle-ui/styles.css` must survive a consumer's
+ * production tree-shaking.
+ *
+ * The jsdom tests above prove the source module registers the tokens, but
+ * jsdom never tree-shakes, so they cannot catch the failure this guards
+ * against. A bare `import 'entangle-ui/styles.css'` resolves to an
+ * exports-less side-effect module; a production bundler keeps it only if its
+ * resolved path is recognized as side-effectful. The contract: the
+ * `./styles.css` export target must be a real `.css` file OR match one of the
+ * `sideEffects` globs. A plain `styles.js` (matching none of `*.css`,
+ * `*.css.ts`, `*.css.js`) is flagged side-effect-free and dropped — silently
+ * shipping a themeless production build. See the `styles.css.js` output name
+ * in `rollup.config.js`.
+ */
+describe('entangle-ui/styles.css (production tree-shaking invariant)', () => {
+  // Vitest runs with the package root as cwd, so the published manifest is
+  // resolvable here without depending on the (transform-mangled)
+  // `import.meta.url`.
+  const pkg = JSON.parse(
+    readFileSync(resolve(process.cwd(), 'package.json'), 'utf8')
+  ) as { exports: Record<string, unknown>; sideEffects: string[] };
+
+  it('resolves ./styles.css to a side-effectful module a bundler will keep', () => {
+    const target = pkg.exports['./styles.css'];
+    expect(typeof target).toBe('string');
+
+    const isSideEffectful =
+      (target as string).endsWith('.css') ||
+      pkg.sideEffects.some(glob =>
+        matchesSideEffectGlob(glob, target as string)
+      );
+
+    // If this fails: the export points at a module (likely `*.js`) that no
+    // `sideEffects` glob covers. Rename the build output so it ends in
+    // `.css.js`, or add a real `.css` target — do NOT just ship a bare `.js`.
+    expect(isSideEffectful).toBe(true);
+  });
+
+  it('lists the three CSS side-effect globs that keep stylesheets alive', () => {
+    // Regression anchor: removing any of these reopens the tree-shaking hole.
+    for (const glob of ['*.css', '*.css.ts', '*.css.js']) {
+      expect(pkg.sideEffects).toContain(glob);
+    }
+  });
+});
+
+/**
+ * Mirror a bundler's `sideEffects` glob matching closely enough to assert the
+ * packaging contract: a glob with no `/` is matched in any directory (webpack
+ * prepends `**\/`), so test it against the basename; `*` matches a run of
+ * non-separator characters.
+ */
+function matchesSideEffectGlob(glob: string, filePath: string): boolean {
+  const subject = glob.includes('/')
+    ? filePath
+    : (filePath.split('/').pop() ?? '');
+  const pattern = glob
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&') // escape regex specials, keep `*`
+    .replace(/\*/g, '[^/]*'); // `*` => any run of non-separator chars
+  return new RegExp(`^${pattern}$`).test(subject);
+}
 
 /** Flatten every stylesheet rule's `cssText` reachable from the document. */
 function collectCssText(): string[] {


### PR DESCRIPTION
## Summary

The canonical theme setup — `import 'entangle-ui/styles.css'` once at the app entry — **silently shipped a themeless production build**. The export resolved to `dist/esm/styles.js`, an exports-less JS shim that imports the dark-theme tokens + global-scrollbar stylesheets for their side effects:

```js
// dist/esm/styles.js
import './assets/src/theme/darkTheme.css.ts.vanilla-….css';
import './assets/src/theme/globalScrollbars.css.ts.vanilla-….css';
```

The package's `sideEffects` allowlist is `["*.css", "*.css.ts", "*.css.js"]`. A plain `styles.js` matches **none** of those globs, and the module exports nothing — so a production bundler flags it side-effect-free and tree-shakes the whole `import 'entangle-ui/styles.css'` away, dropping the dark-theme `:root { --etui-* }` block. The built CSS then has every token *used* (`var(--etui-*)`) but **zero token definitions**, so colours, fonts and z-index all resolve to nothing (no colours, no fonts, menus/tooltips with no background or stacking).

Dev (Vite dev server) is unaffected because it doesn't tree-shake — the failure only appears in `build` / `preview`. 🔴 Production-breaking, reported against `0.11.0`.

## Root cause

`styles.js` is the **only** entry that is pure side effect (zero exports). Component `*.css.js` modules survive because they export class-name objects that get *used*; `styles.js` had nothing to anchor it, and its `.js` name fell outside every `sideEffects` glob.

## Fix

Emit the stylesheet entry as **`dist/esm/styles.css.js`** instead of `styles.js` (Rollup input key rename) and point the `./styles.css` export at it. The `.css.js` suffix matches the existing, proven `*.css.js` glob — the same side-effect bucket as all 92 component style modules — so the import is preserved through production tree-shaking. No consumer-side change required.

I chose the rename over adding a path-specific `sideEffects` entry because it reuses an already-proven glob, is self-documenting (the file name signals it's a CSS side-effect module), and generalizes to any future side-effect-only stylesheet shim.

## Verification (real bundler, end-to-end)

A minimal consumer (`import 'entangle-ui/styles.css'`) built with **Vite production** (= Rollup, honors `sideEffects`), installed from `npm pack` so the real `exports`/`sideEffects` resolution is exercised:

| | CSS emitted | `--etui-*` definitions | `etuiGlobalScrollbars` rule |
|---|---|---|---|
| **Before** | ❌ 0 bytes (import fully tree-shaken) | 0 | ✗ |
| **After** | ✅ `index.css` 4.13 kB | 97 | ✓ |

After the fix, `--etui-color-bg-primary: #1a1a1a` and the rest of the tokens land on `:root` in both dev and prod.

## Regression guard

Added a static packaging-invariant test in `src/styles.test.ts`. The existing jsdom tests can't catch this (jsdom never tree-shakes), so the new test asserts the contract directly: the `./styles.css` export target must be a real `.css` **or** match a `sideEffects` glob. It fails on the old `styles.js` value and passes on `styles.css.js`, and pins the three CSS side-effect globs so removing one trips the suite.

## Scope

- `rollup.config.js` — input key `styles` → `styles.css` (+ explanatory comment)
- `package.json` — `./styles.css` export → `./dist/esm/styles.css.js`
- `src/styles.test.ts` — packaging-invariant regression guard
- changeset (patch)

No other `*.js` re-export of side-effect-only CSS exists in the build (verified by scanning `dist/esm`), so `styles.css` was the only affected entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9jaWxbtR4WNrYDLk21GHx

---
_Generated by [Claude Code](https://claude.ai/code/session_01K9jaWxbtR4WNrYDLk21GHx)_